### PR TITLE
fix: use correct tag format with v prefix in GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,7 +158,7 @@ jobs:
       uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2.4.1
       with:
         body_path: body.md
-        tag_name: ${{ steps.cz.outputs.version }}
+        tag_name: v${{ steps.cz.outputs.version }}
         files: dist/*
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -5,4 +5,4 @@ from champi_imgui import __version__
 
 def test_version():
     """Test that version is set."""
-    assert __version__ == "0.0.1"
+    assert __version__ == "0.0.2"

--- a/uv.lock
+++ b/uv.lock
@@ -159,7 +159,7 @@ wheels = [
 
 [[package]]
 name = "champi-imgui"
-version = "0.0.1"
+version = "0.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "blinker" },


### PR DESCRIPTION
## Summary
- Fixed GitHub release creation to use correct tag format with `v` prefix
- Changed `tag_name` from `${{ steps.cz.outputs.version }}` to `v${{ steps.cz.outputs.version }}`
- Ensures releases are created as `v0.0.2` instead of `0.0.2`
- Matches the `tag_format = "v$version"` configured in pyproject.toml

## Root Cause
The workflow was outputting version as `0.0.2` (without v prefix) and using it directly as tag_name. Commitizen creates git tags with "v" prefix correctly, but the GitHub release was being created without it, causing a mismatch.

## Testing
- After merge, the next release will create GitHub releases with proper `v` prefix
- Existing release `0.0.2` should be deleted and recreated as `v0.0.2` for consistency

## Related
- Fixes the issue discovered after PR #1 merge where releases were created with incorrect tag format