### PR TITLE
feat: Stage 5 - Core Canvas System with Shared Memory IPC

### DIFF
--- a/src/champi_imgui/cli.py
+++ b/src/champi_imgui/cli.py
@@ -1,0 +1,56 @@
+"""CLI entry point for champi-imgui MCP server."""
+
+import atexit
+import signal
+import sys
+
+from loguru import logger
+
+from champi_imgui.server.main import canvas_manager, mcp
+
+
+def cleanup() -> None:
+    """Cleanup handler for shutdown."""
+    logger.info("Shutting down champi-imgui...")
+    canvas_manager.cleanup()
+    logger.info("Shutdown complete")
+
+
+def signal_handler(signum: int, frame: object) -> None:
+    """Handle interrupt signals gracefully."""
+    logger.info(f"Received signal {signum}, shutting down...")
+    cleanup()
+    sys.exit(0)
+
+
+def main() -> None:
+    """Main entry point for champi-imgui CLI."""
+    # Configure logger
+    logger.remove()  # Remove default handler
+    logger.add(
+        sys.stderr,
+        level="INFO",
+        format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>",
+    )
+
+    logger.info("Starting champi-imgui MCP server...")
+
+    # Register cleanup handlers
+    atexit.register(cleanup)
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    try:
+        # Run FastMCP server (blocking)
+        mcp.run()
+    except KeyboardInterrupt:
+        logger.info("Received keyboard interrupt")
+    except Exception as e:
+        logger.error(f"Error running MCP server: {e}")
+        raise
+    finally:
+        cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/champi_imgui/core/__init__.py
+++ b/src/champi_imgui/core/__init__.py
@@ -1,0 +1,6 @@
+"""Core module for Canvas state and management."""
+
+from champi_imgui.core.canvas import Canvas, CanvasManager
+from champi_imgui.core.state import CanvasState
+
+__all__ = ["Canvas", "CanvasManager", "CanvasState"]

--- a/src/champi_imgui/core/canvas.py
+++ b/src/champi_imgui/core/canvas.py
@@ -1,0 +1,286 @@
+"""Canvas management with IPC-based rendering.
+
+Canvas runs in a separate thread, processing commands via shared memory
+from the MCP server.
+"""
+
+import threading
+from typing import Any
+
+from imgui_bundle import hello_imgui, imgui
+from loguru import logger
+
+from champi_imgui.core.state import CanvasState
+from champi_imgui.ipc.command_types import CommandType
+from champi_imgui.ipc.shared_memory_manager import SharedMemoryManager
+
+
+class Canvas:
+    """Canvas window with event-driven rendering.
+
+    The canvas runs in a background thread and processes commands
+    from shared memory regions. Window appears immediately when created.
+    """
+
+    def __init__(self, canvas_id: str, **kwargs: Any):
+        """Initialize canvas.
+
+        Args:
+            canvas_id: Unique identifier for canvas
+            **kwargs: Canvas state parameters (title, size, etc.)
+        """
+        self.state = CanvasState(canvas_id=canvas_id, **kwargs)
+        self.shm_manager = SharedMemoryManager(name_prefix=f"canvas_{canvas_id}")
+
+        # Thread control
+        self._running = False
+        self._render_thread: threading.Thread | None = None
+
+        # Create shared memory regions (Canvas is the creator)
+        self.shm_manager.create_regions()
+        logger.info(f"Canvas '{canvas_id}' initialized with shared memory")
+
+    def run_async(self) -> None:
+        """Start canvas in background thread (non-blocking).
+
+        Window appears immediately and begins processing commands.
+        """
+        if self._running:
+            logger.warning(f"Canvas '{self.state.canvas_id}' already running")
+            return
+
+        self._running = True
+        self._render_thread = threading.Thread(
+            target=self._render_loop, daemon=True, name=f"Canvas-{self.state.canvas_id}"
+        )
+        self._render_thread.start()
+        logger.info(f"Canvas '{self.state.canvas_id}' started in background thread")
+
+    def stop(self) -> None:
+        """Stop canvas rendering and cleanup."""
+        if not self._running:
+            return
+
+        self._running = False
+        if self._render_thread is not None:
+            self._render_thread.join(timeout=2.0)
+            logger.info(f"Canvas '{self.state.canvas_id}' stopped")
+
+        # Cleanup shared memory
+        self.shm_manager.cleanup()
+
+    def _render_loop(self) -> None:
+        """Main render loop (runs in background thread).
+
+        Event-driven: polls for commands and renders UI accordingly.
+        """
+        # Configure HelloImGui runner params
+        runner_params = hello_imgui.RunnerParams()
+        runner_params.app_window_params.window_title = self.state.title
+        runner_params.app_window_params.window_geometry.size = self.state.size
+
+        # FPS idling configuration (event-driven, not continuous)
+        runner_params.fps_idling.enable_idling = True
+        runner_params.fps_idling.fps_idle = 10  # Low FPS when idle
+
+        # Callbacks
+        runner_params.callbacks.show_gui = self._render_frame
+        runner_params.callbacks.before_exit = self._on_exit
+
+        # Run ImGui app (blocking until window closed)
+        try:
+            hello_imgui.run(runner_params)
+        except Exception as e:
+            logger.error(f"Error in render loop for '{self.state.canvas_id}': {e}")
+        finally:
+            self._running = False
+
+    def _render_frame(self) -> None:
+        """Render a single frame (called by ImGui loop).
+
+        Processes commands from shared memory and renders UI.
+        """
+        # Process pending commands
+        self._process_commands()
+
+        # Render canvas content
+        imgui.begin(
+            self.state.title,
+            flags=imgui.WindowFlags_.no_collapse,
+        )
+
+        # Placeholder content for Stage 5
+        imgui.text(f"Canvas ID: {self.state.canvas_id}")
+        imgui.text(f"Size: {self.state.size[0]} x {self.state.size[1]}")
+        imgui.separator()
+        imgui.text("Ready for widgets (Stage 6)")
+
+        imgui.end()
+
+    def _process_commands(self) -> None:
+        """Process all pending commands from shared memory."""
+        while self._running:
+            # Non-blocking read
+            command_data = self.shm_manager.read_command(timeout=0.0)
+            if command_data is None:
+                break
+
+            logger.debug(
+                f"Processing command: {command_data.command_type.name} (seq={command_data.seq_num})"
+            )
+
+            # Handle command
+            try:
+                if command_data.command_type == CommandType.CLEAR_CANVAS:
+                    self._handle_clear_canvas(command_data.data)
+                elif command_data.command_type == CommandType.UPDATE_STATE:
+                    self._handle_update_state(command_data.data)
+                elif command_data.command_type == CommandType.SHUTDOWN:
+                    self._handle_shutdown(command_data.data)
+                else:
+                    logger.warning(
+                        f"Unknown command type: {command_data.command_type.name}"
+                    )
+
+                # Send acknowledgment
+                self.shm_manager.write_ack(command_data.seq_num)
+            except Exception as e:
+                logger.error(
+                    f"Error processing command {command_data.command_type.name}: {e}"
+                )
+
+    def _handle_clear_canvas(self, data: dict[str, Any]) -> None:
+        """Handle CLEAR_CANVAS command."""
+        canvas_id = data.get("canvas_id")
+        if canvas_id != self.state.canvas_id:
+            logger.warning(
+                f"Clear command for wrong canvas: {canvas_id} (expected {self.state.canvas_id})"
+            )
+            return
+
+        logger.info(f"Clearing canvas '{canvas_id}'")
+        # Stage 6 will implement actual widget clearing
+
+    def _handle_update_state(self, data: dict[str, Any]) -> None:
+        """Handle UPDATE_STATE command."""
+        canvas_id = data.get("canvas_id")
+        if canvas_id != self.state.canvas_id:
+            logger.warning(
+                f"Update command for wrong canvas: {canvas_id} (expected {self.state.canvas_id})"
+            )
+            return
+
+        # Update state
+        if "title" in data:
+            self.state.title = data["title"]
+        if "width" in data and "height" in data:
+            self.state.size = (data["width"], data["height"])
+
+        logger.info(f"Updated state for canvas '{canvas_id}'")
+
+    def _handle_shutdown(self, data: dict[str, Any]) -> None:
+        """Handle SHUTDOWN command."""
+        canvas_id = data.get("canvas_id")
+        if canvas_id != self.state.canvas_id:
+            logger.warning(
+                f"Shutdown command for wrong canvas: {canvas_id} (expected {self.state.canvas_id})"
+            )
+            return
+
+        logger.info(f"Shutting down canvas '{canvas_id}'")
+        self._running = False
+
+    def _on_exit(self) -> None:
+        """Cleanup on window close."""
+        logger.info(f"Canvas '{self.state.canvas_id}' window closed")
+        self._running = False
+
+
+class CanvasManager:
+    """Manages multiple Canvas instances.
+
+    Provides centralized access to all canvases and ensures proper cleanup.
+    """
+
+    def __init__(self):
+        """Initialize canvas manager."""
+        self.canvases: dict[str, Canvas] = {}
+        logger.info("CanvasManager initialized")
+
+    def create_canvas(
+        self, canvas_id: str, auto_start: bool = True, **kwargs: Any
+    ) -> Canvas:
+        """Create a new canvas.
+
+        Args:
+            canvas_id: Unique identifier for canvas
+            auto_start: Whether to automatically start rendering
+            **kwargs: Canvas state parameters
+
+        Returns:
+            Created Canvas instance
+
+        Raises:
+            ValueError: If canvas with same ID already exists
+        """
+        if canvas_id in self.canvases:
+            msg = f"Canvas '{canvas_id}' already exists"
+            raise ValueError(msg)
+
+        canvas = Canvas(canvas_id, **kwargs)
+        self.canvases[canvas_id] = canvas
+
+        if auto_start:
+            canvas.run_async()
+
+        logger.info(f"Created canvas '{canvas_id}' (auto_start={auto_start})")
+        return canvas
+
+    def get_canvas(self, canvas_id: str) -> Canvas | None:
+        """Get canvas by ID.
+
+        Args:
+            canvas_id: Canvas identifier
+
+        Returns:
+            Canvas instance or None if not found
+        """
+        return self.canvases.get(canvas_id)
+
+    def list_canvases(self) -> list[str]:
+        """List all canvas IDs.
+
+        Returns:
+            List of canvas IDs
+        """
+        return list(self.canvases.keys())
+
+    def ensure_canvas_running(self, canvas_id: str) -> bool:
+        """Ensure canvas is running.
+
+        Args:
+            canvas_id: Canvas identifier
+
+        Returns:
+            True if canvas is running, False if not found
+        """
+        canvas = self.get_canvas(canvas_id)
+        if canvas is None:
+            return False
+
+        if not canvas._running:
+            canvas.run_async()
+
+        return True
+
+    def cleanup(self) -> None:
+        """Stop all canvases and cleanup resources."""
+        logger.info("Cleaning up all canvases...")
+        for canvas_id, canvas in self.canvases.items():
+            try:
+                canvas.stop()
+            except Exception as e:
+                logger.error(f"Error stopping canvas '{canvas_id}': {e}")
+
+        self.canvases.clear()
+        logger.info("All canvases cleaned up")

--- a/src/champi_imgui/core/state.py
+++ b/src/champi_imgui/core/state.py
@@ -1,0 +1,76 @@
+"""Canvas state management using dataclasses.
+
+Defines the core state structure for Canvas instances.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class CanvasState:
+    """State for a Canvas instance.
+
+    Tracks the configuration and runtime state of a canvas window.
+    """
+
+    canvas_id: str
+    """Unique identifier for the canvas"""
+
+    title: str = "Canvas"
+    """Window title"""
+
+    size: tuple[int, int] = (800, 600)
+    """Window size (width, height) in pixels"""
+
+    position: tuple[int, int] | None = None
+    """Window position (x, y) in pixels. None = auto-position"""
+
+    visible: bool = True
+    """Whether the canvas window is visible"""
+
+    fps_target: int = 60
+    """Target frames per second for rendering"""
+
+    properties: dict[str, Any] = field(default_factory=dict)
+    """Additional canvas properties (extensible)"""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert state to dictionary for serialization.
+
+        Returns:
+            Dictionary representation of canvas state
+        """
+        return {
+            "canvas_id": self.canvas_id,
+            "title": self.title,
+            "size": list(self.size),
+            "position": list(self.position) if self.position else None,
+            "visible": self.visible,
+            "fps_target": self.fps_target,
+            "properties": self.properties,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "CanvasState":
+        """Create CanvasState from dictionary.
+
+        Args:
+            data: Dictionary with canvas state data
+
+        Returns:
+            CanvasState instance
+        """
+        size = tuple(data.get("size", [800, 600]))
+        position_list = data.get("position")
+        position = tuple(position_list) if position_list else None
+
+        return cls(
+            canvas_id=data["canvas_id"],
+            title=data.get("title", "Canvas"),
+            size=size,
+            position=position,
+            visible=data.get("visible", True),
+            fps_target=data.get("fps_target", 60),
+            properties=data.get("properties", {}),
+        )

--- a/src/champi_imgui/ipc/__init__.py
+++ b/src/champi_imgui/ipc/__init__.py
@@ -1,0 +1,13 @@
+"""IPC (Inter-Process Communication) module for Canvas and MCP server."""
+
+from champi_imgui.ipc.command_types import CommandType
+from champi_imgui.ipc.shared_memory_manager import SharedMemoryManager
+from champi_imgui.ipc.structs import CommandData, pack_command, unpack_command
+
+__all__ = [
+    "CommandData",
+    "CommandType",
+    "SharedMemoryManager",
+    "pack_command",
+    "unpack_command",
+]

--- a/src/champi_imgui/ipc/command_types.py
+++ b/src/champi_imgui/ipc/command_types.py
@@ -1,0 +1,25 @@
+"""Command types for IPC between MCP server and Canvas render process."""
+
+from enum import IntEnum
+
+
+class CommandType(IntEnum):
+    """Command type identifiers for Canvas IPC.
+
+    These commands are sent from MCP server to Canvas render process
+    via shared memory regions.
+    """
+
+    # Canvas management
+    CREATE_CANVAS = 1  # Initialize new canvas (placeholder, canvas already exists)
+    CLEAR_CANVAS = 2  # Clear all widgets from canvas
+    UPDATE_STATE = 3  # Update canvas properties (title, size, etc.)
+    SHUTDOWN = 4  # Gracefully shutdown canvas
+
+    # Widget operations (placeholders for Stage 6)
+    ADD_WIDGET = 10  # Add widget to canvas
+    UPDATE_WIDGET = 11  # Update widget properties
+    REMOVE_WIDGET = 12  # Remove widget from canvas
+
+    # Response/acknowledgment
+    ACK = 99  # Acknowledgment response

--- a/src/champi_imgui/ipc/shared_memory_manager.py
+++ b/src/champi_imgui/ipc/shared_memory_manager.py
@@ -1,0 +1,252 @@
+"""Shared memory manager for IPC between MCP server and Canvas render process.
+
+Adapted from mcp_champi/ipc_svc/ shared memory pattern.
+"""
+
+import struct
+import time
+from multiprocessing import shared_memory
+from typing import Any
+
+from loguru import logger
+
+from champi_imgui.ipc.command_types import CommandType
+from champi_imgui.ipc.structs import (
+    CommandData,
+    pack_ack,
+    pack_command,
+    unpack_ack,
+    unpack_command,
+)
+
+# Maximum size for command region (use largest struct)
+MAX_COMMAND_SIZE = 512
+
+
+class SharedMemoryManager:
+    """Manages shared memory regions for Canvas IPC.
+
+    Canvas process creates memory regions (producer).
+    MCP server attaches to existing regions (consumer).
+
+    Memory layout per canvas:
+    - Command region: MCP server writes commands, Canvas reads
+    - ACK region: Canvas writes acknowledgments, MCP server reads
+    """
+
+    def __init__(self, name_prefix: str = "canvas"):
+        """Initialize shared memory manager.
+
+        Args:
+            name_prefix: Prefix for shared memory region names
+                        (e.g., "canvas_main" creates "canvas_main_cmd")
+        """
+        self.name_prefix = name_prefix
+        self.cmd_region: shared_memory.SharedMemory | None = None
+        self.ack_region: shared_memory.SharedMemory | None = None
+        self.is_creator = False
+        self._seq_num = 0
+
+    def create_regions(self) -> None:
+        """Create shared memory regions (Canvas process only).
+
+        Creates two regions:
+        - Command region: For commands from MCP server
+        - ACK region: For acknowledgments from Canvas
+        """
+        self.is_creator = True
+
+        # Create command region
+        cmd_name = f"{self.name_prefix}_cmd"
+        try:
+            self.cmd_region = shared_memory.SharedMemory(
+                name=cmd_name, create=True, size=MAX_COMMAND_SIZE
+            )
+            # Initialize with zeros
+            self.cmd_region.buf[:] = bytes(MAX_COMMAND_SIZE)
+            logger.debug(f"Created command region: {cmd_name}")
+        except FileExistsError:
+            # Region already exists, attach to it
+            logger.warning(
+                f"Command region {cmd_name} already exists, attaching instead"
+            )
+            self.cmd_region = shared_memory.SharedMemory(name=cmd_name)
+
+        # Create ACK region
+        ack_name = f"{self.name_prefix}_ack"
+        try:
+            self.ack_region = shared_memory.SharedMemory(
+                name=ack_name,
+                create=True,
+                size=8,  # Just sequence number
+            )
+            self.ack_region.buf[:] = bytes(8)
+            logger.debug(f"Created ACK region: {ack_name}")
+        except FileExistsError:
+            logger.warning(f"ACK region {ack_name} already exists, attaching instead")
+            self.ack_region = shared_memory.SharedMemory(name=ack_name)
+
+    def attach_regions(self) -> None:
+        """Attach to existing shared memory regions (MCP server only).
+
+        Attaches to regions created by Canvas process.
+        """
+        self.is_creator = False
+
+        # Attach to command region
+        cmd_name = f"{self.name_prefix}_cmd"
+        self.cmd_region = shared_memory.SharedMemory(name=cmd_name)
+        logger.debug(f"Attached to command region: {cmd_name}")
+
+        # Attach to ACK region
+        ack_name = f"{self.name_prefix}_ack"
+        self.ack_region = shared_memory.SharedMemory(name=ack_name)
+        logger.debug(f"Attached to ACK region: {ack_name}")
+
+    def write_command(self, command_type: CommandType, **kwargs: Any) -> int:
+        """Write command to shared memory (MCP server side).
+
+        Args:
+            command_type: Type of command to write
+            **kwargs: Command-specific data
+
+        Returns:
+            Sequence number of written command
+        """
+        if self.cmd_region is None:
+            msg = "Command region not initialized. Call attach_regions() first."
+            raise RuntimeError(msg)
+
+        self._seq_num += 1
+        seq_num = self._seq_num
+
+        # Pack command
+        command_bytes = pack_command(command_type, seq_num, **kwargs)
+
+        # Write to shared memory
+        size = len(command_bytes)
+        self.cmd_region.buf[:size] = command_bytes
+
+        logger.debug(f"Wrote command {command_type.name} (seq={seq_num})")
+        return seq_num
+
+    def read_command(self, timeout: float = 0.0) -> CommandData | None:
+        """Read command from shared memory (Canvas side).
+
+        Args:
+            timeout: Maximum time to wait for command (0 = non-blocking)
+
+        Returns:
+            CommandData if available, None otherwise
+        """
+        if self.cmd_region is None:
+            msg = "Command region not initialized. Call create_regions() first."
+            raise RuntimeError(msg)
+
+        start_time = time.time()
+
+        while True:
+            # Read from shared memory
+            data = bytes(self.cmd_region.buf[:MAX_COMMAND_SIZE])
+
+            # Check if data is all zeros (no command)
+            if data == bytes(MAX_COMMAND_SIZE):
+                if timeout == 0:
+                    return None
+                if time.time() - start_time >= timeout:
+                    return None
+                time.sleep(0.001)  # Short sleep to avoid busy-wait
+                continue
+
+            # Unpack command
+            try:
+                command_data = unpack_command(data)
+                # Clear the command region after reading
+                self.cmd_region.buf[:] = bytes(MAX_COMMAND_SIZE)
+                logger.debug(
+                    f"Read command {command_data.command_type.name} (seq={command_data.seq_num})"
+                )
+                return command_data
+            except (ValueError, struct.error) as e:
+                logger.error(f"Error unpacking command: {e}")
+                # Clear invalid data
+                self.cmd_region.buf[:] = bytes(MAX_COMMAND_SIZE)
+                return None
+
+    def write_ack(self, seq_num: int) -> None:
+        """Write acknowledgment to shared memory (Canvas side).
+
+        Args:
+            seq_num: Sequence number to acknowledge
+        """
+        if self.ack_region is None:
+            msg = "ACK region not initialized. Call create_regions() first."
+            raise RuntimeError(msg)
+
+        ack_bytes = pack_ack(seq_num)
+        self.ack_region.buf[:8] = ack_bytes
+        logger.debug(f"Wrote ACK for seq={seq_num}")
+
+    def read_ack(self, timeout: float = 1.0) -> int | None:
+        """Read acknowledgment from shared memory (MCP server side).
+
+        Args:
+            timeout: Maximum time to wait for ACK
+
+        Returns:
+            Sequence number if ACK received, None otherwise
+        """
+        if self.ack_region is None:
+            msg = "ACK region not initialized. Call attach_regions() first."
+            raise RuntimeError(msg)
+
+        start_time = time.time()
+
+        while True:
+            data = bytes(self.ack_region.buf[:8])
+
+            # Check if data is all zeros (no ACK)
+            if data == bytes(8):
+                if time.time() - start_time >= timeout:
+                    return None
+                time.sleep(0.001)
+                continue
+
+            # Unpack ACK
+            try:
+                seq_num = unpack_ack(data)
+                # Clear ACK after reading
+                self.ack_region.buf[:] = bytes(8)
+                logger.debug(f"Read ACK for seq={seq_num}")
+                return seq_num
+            except struct.error as e:
+                logger.error(f"Error unpacking ACK: {e}")
+                return None
+
+    def cleanup(self) -> None:
+        """Close and optionally unlink shared memory regions."""
+        if self.cmd_region is not None:
+            self.cmd_region.close()
+            if self.is_creator:
+                try:
+                    self.cmd_region.unlink()
+                    logger.debug(f"Unlinked command region: {self.name_prefix}_cmd")
+                except FileNotFoundError:
+                    pass
+
+        if self.ack_region is not None:
+            self.ack_region.close()
+            if self.is_creator:
+                try:
+                    self.ack_region.unlink()
+                    logger.debug(f"Unlinked ACK region: {self.name_prefix}_ack")
+                except FileNotFoundError:
+                    pass
+
+    def __enter__(self) -> "SharedMemoryManager":
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Context manager exit with cleanup."""
+        self.cleanup()

--- a/src/champi_imgui/ipc/structs.py
+++ b/src/champi_imgui/ipc/structs.py
@@ -1,0 +1,225 @@
+"""Binary struct serialization for IPC commands.
+
+Fixed-size structs for efficient shared memory communication between
+MCP server and Canvas render process.
+"""
+
+import struct
+from dataclasses import dataclass
+from typing import Any
+
+from champi_imgui.ipc.command_types import CommandType
+
+# Size constants (in bytes)
+MAX_CANVAS_ID_SIZE = 64
+MAX_TITLE_SIZE = 128
+MAX_WIDGET_ID_SIZE = 64
+MAX_WIDGET_TYPE_SIZE = 32
+
+# Padding character for fixed-size strings
+PAD_CHAR = b"#"
+
+# Struct definitions
+# Format: '=' (native byte order), 'Q' (8-byte unsigned long), 'B' (1-byte unsigned char)
+HEADER_STRUCT = struct.Struct("=QB")  # seq_num + command_type
+
+CLEAR_CANVAS_STRUCT = struct.Struct(
+    f"=QB{MAX_CANVAS_ID_SIZE}s"
+)  # seq_num + cmd_type + canvas_id
+
+UPDATE_STATE_STRUCT = struct.Struct(
+    f"=QB{MAX_CANVAS_ID_SIZE}s{MAX_TITLE_SIZE}sII"
+)  # seq_num + cmd_type + canvas_id + title + width + height
+
+SHUTDOWN_STRUCT = struct.Struct(
+    f"=QB{MAX_CANVAS_ID_SIZE}s"
+)  # seq_num + cmd_type + canvas_id
+
+# Placeholder for Stage 6
+ADD_WIDGET_STRUCT = struct.Struct(
+    f"=QB{MAX_CANVAS_ID_SIZE}s{MAX_WIDGET_ID_SIZE}s{MAX_WIDGET_TYPE_SIZE}s"
+)  # seq_num + cmd_type + canvas_id + widget_id + widget_type
+
+ACK_STRUCT = struct.Struct("=Q")  # seq_num only
+
+
+@dataclass
+class CommandData:
+    """Parsed command data from binary struct."""
+
+    command_type: CommandType
+    seq_num: int
+    data: dict[str, Any]
+
+
+def _pad_string(s: str, size: int) -> bytes:
+    """Pad string to fixed size with PAD_CHAR."""
+    encoded = s.encode("utf-8")[:size]
+    return encoded.ljust(size, PAD_CHAR)
+
+
+def _unpad_string(b: bytes) -> str:
+    """Remove padding from fixed-size string."""
+    return b.rstrip(PAD_CHAR).decode("utf-8", errors="ignore")
+
+
+def get_struct_size(command_type: CommandType) -> int:
+    """Get the size in bytes for a command type."""
+    if command_type == CommandType.CLEAR_CANVAS:
+        return CLEAR_CANVAS_STRUCT.size
+    elif command_type == CommandType.UPDATE_STATE:
+        return UPDATE_STATE_STRUCT.size
+    elif command_type == CommandType.SHUTDOWN:
+        return SHUTDOWN_STRUCT.size
+    elif command_type == CommandType.ADD_WIDGET:
+        return ADD_WIDGET_STRUCT.size
+    elif command_type == CommandType.ACK:
+        return ACK_STRUCT.size
+    else:
+        # Default to largest struct
+        return max(
+            CLEAR_CANVAS_STRUCT.size,
+            UPDATE_STATE_STRUCT.size,
+            SHUTDOWN_STRUCT.size,
+            ADD_WIDGET_STRUCT.size,
+        )
+
+
+def pack_command(command_type: CommandType, seq_num: int, **kwargs: Any) -> bytes:
+    """Pack command data into binary struct.
+
+    Args:
+        command_type: Type of command to pack
+        seq_num: Sequence number for tracking
+        **kwargs: Command-specific data
+
+    Returns:
+        Binary struct data
+    """
+    if command_type == CommandType.CLEAR_CANVAS:
+        canvas_id = kwargs.get("canvas_id", "")
+        return CLEAR_CANVAS_STRUCT.pack(
+            seq_num, command_type, _pad_string(canvas_id, MAX_CANVAS_ID_SIZE)
+        )
+
+    elif command_type == CommandType.UPDATE_STATE:
+        canvas_id = kwargs.get("canvas_id", "")
+        title = kwargs.get("title", "")
+        width = kwargs.get("width", 800)
+        height = kwargs.get("height", 600)
+        return UPDATE_STATE_STRUCT.pack(
+            seq_num,
+            command_type,
+            _pad_string(canvas_id, MAX_CANVAS_ID_SIZE),
+            _pad_string(title, MAX_TITLE_SIZE),
+            width,
+            height,
+        )
+
+    elif command_type == CommandType.SHUTDOWN:
+        canvas_id = kwargs.get("canvas_id", "")
+        return SHUTDOWN_STRUCT.pack(
+            seq_num, command_type, _pad_string(canvas_id, MAX_CANVAS_ID_SIZE)
+        )
+
+    elif command_type == CommandType.ADD_WIDGET:
+        # Placeholder for Stage 6
+        canvas_id = kwargs.get("canvas_id", "")
+        widget_id = kwargs.get("widget_id", "")
+        widget_type = kwargs.get("widget_type", "")
+        return ADD_WIDGET_STRUCT.pack(
+            seq_num,
+            command_type,
+            _pad_string(canvas_id, MAX_CANVAS_ID_SIZE),
+            _pad_string(widget_id, MAX_WIDGET_ID_SIZE),
+            _pad_string(widget_type, MAX_WIDGET_TYPE_SIZE),
+        )
+
+    else:
+        msg = f"Unknown command type: {command_type}"
+        raise ValueError(msg)
+
+
+def unpack_command(data: bytes) -> CommandData:
+    """Unpack binary struct into command data.
+
+    Args:
+        data: Binary struct data
+
+    Returns:
+        CommandData with parsed fields
+    """
+    # Read header first
+    seq_num, cmd_type_int = HEADER_STRUCT.unpack(data[: HEADER_STRUCT.size])
+    command_type = CommandType(cmd_type_int)
+
+    # Unpack based on command type
+    if command_type == CommandType.CLEAR_CANVAS:
+        seq_num, cmd_type_int, canvas_id_bytes = CLEAR_CANVAS_STRUCT.unpack(data)
+        return CommandData(
+            command_type=command_type,
+            seq_num=seq_num,
+            data={"canvas_id": _unpad_string(canvas_id_bytes)},
+        )
+
+    elif command_type == CommandType.UPDATE_STATE:
+        (
+            seq_num,
+            cmd_type_int,
+            canvas_id_bytes,
+            title_bytes,
+            width,
+            height,
+        ) = UPDATE_STATE_STRUCT.unpack(data)
+        return CommandData(
+            command_type=command_type,
+            seq_num=seq_num,
+            data={
+                "canvas_id": _unpad_string(canvas_id_bytes),
+                "title": _unpad_string(title_bytes),
+                "width": width,
+                "height": height,
+            },
+        )
+
+    elif command_type == CommandType.SHUTDOWN:
+        seq_num, cmd_type_int, canvas_id_bytes = SHUTDOWN_STRUCT.unpack(data)
+        return CommandData(
+            command_type=command_type,
+            seq_num=seq_num,
+            data={"canvas_id": _unpad_string(canvas_id_bytes)},
+        )
+
+    elif command_type == CommandType.ADD_WIDGET:
+        # Placeholder for Stage 6
+        (
+            seq_num,
+            cmd_type_int,
+            canvas_id_bytes,
+            widget_id_bytes,
+            widget_type_bytes,
+        ) = ADD_WIDGET_STRUCT.unpack(data)
+        return CommandData(
+            command_type=command_type,
+            seq_num=seq_num,
+            data={
+                "canvas_id": _unpad_string(canvas_id_bytes),
+                "widget_id": _unpad_string(widget_id_bytes),
+                "widget_type": _unpad_string(widget_type_bytes),
+            },
+        )
+
+    else:
+        msg = f"Unknown command type: {command_type}"
+        raise ValueError(msg)
+
+
+def pack_ack(seq_num: int) -> bytes:
+    """Pack acknowledgment with sequence number."""
+    return ACK_STRUCT.pack(seq_num)
+
+
+def unpack_ack(data: bytes) -> int:
+    """Unpack acknowledgment to get sequence number."""
+    result = ACK_STRUCT.unpack(data)
+    return int(result[0])

--- a/src/champi_imgui/server/__init__.py
+++ b/src/champi_imgui/server/__init__.py
@@ -1,0 +1,5 @@
+"""MCP server module for champi-imgui."""
+
+from champi_imgui.server.main import mcp
+
+__all__ = ["mcp"]

--- a/src/champi_imgui/server/main.py
+++ b/src/champi_imgui/server/main.py
@@ -1,0 +1,314 @@
+"""FastMCP server for champi-imgui.
+
+Provides MCP tools for creating and managing Canvas windows through
+shared memory IPC.
+"""
+
+from typing import Any
+
+from fastmcp import FastMCP
+from loguru import logger
+
+from champi_imgui.core.canvas import CanvasManager
+from champi_imgui.ipc.command_types import CommandType
+from champi_imgui.ipc.shared_memory_manager import SharedMemoryManager
+
+# Global canvas manager (single instance for all MCP tool calls)
+canvas_manager = CanvasManager()
+
+# FastMCP server instance
+mcp = FastMCP("champi-imgui")
+
+
+@mcp.tool()
+def create_canvas(
+    canvas_id: str,
+    title: str = "Canvas",
+    width: int = 800,
+    height: int = 600,
+    auto_start: bool = True,
+) -> dict[str, Any]:
+    """Create a new canvas window.
+
+    The canvas window will appear immediately and run in a background thread.
+    Commands can be sent to the canvas via other MCP tools.
+
+    Args:
+        canvas_id: Unique identifier for the canvas
+        title: Window title
+        width: Window width in pixels
+        height: Window height in pixels
+        auto_start: Whether to automatically start rendering (default: True)
+
+    Returns:
+        Success status and canvas state data
+    """
+    try:
+        # Check if canvas already exists
+        existing = canvas_manager.get_canvas(canvas_id)
+        if existing is not None:
+            return {
+                "success": False,
+                "error": f"Canvas '{canvas_id}' already exists",
+            }
+
+        # Create canvas (window appears immediately if auto_start=True)
+        canvas = canvas_manager.create_canvas(
+            canvas_id=canvas_id,
+            title=title,
+            size=(width, height),
+            auto_start=auto_start,
+        )
+
+        logger.info(f"Created canvas '{canvas_id}' via MCP tool")
+
+        return {
+            "success": True,
+            "data": canvas.state.to_dict(),
+        }
+
+    except Exception as e:
+        logger.error(f"Error creating canvas '{canvas_id}': {e}")
+        return {
+            "success": False,
+            "error": str(e),
+        }
+
+
+@mcp.tool()
+def get_canvas_state(canvas_id: str) -> dict[str, Any]:
+    """Get the current state of a canvas.
+
+    Args:
+        canvas_id: Canvas identifier
+
+    Returns:
+        Success status and canvas state data
+    """
+    try:
+        canvas = canvas_manager.get_canvas(canvas_id)
+        if canvas is None:
+            return {
+                "success": False,
+                "error": f"Canvas '{canvas_id}' not found",
+            }
+
+        return {
+            "success": True,
+            "data": canvas.state.to_dict(),
+        }
+
+    except Exception as e:
+        logger.error(f"Error getting canvas state for '{canvas_id}': {e}")
+        return {
+            "success": False,
+            "error": str(e),
+        }
+
+
+@mcp.tool()
+def clear_canvas(canvas_id: str) -> dict[str, Any]:
+    """Clear all widgets from a canvas.
+
+    Sends a CLEAR_CANVAS command via shared memory to the canvas render thread.
+    The command is processed asynchronously (fire-and-forget).
+
+    Args:
+        canvas_id: Canvas identifier
+
+    Returns:
+        Success status
+    """
+    try:
+        canvas = canvas_manager.get_canvas(canvas_id)
+        if canvas is None:
+            return {
+                "success": False,
+                "error": f"Canvas '{canvas_id}' not found",
+            }
+
+        # Ensure canvas is running
+        if not canvas._running:
+            canvas.run_async()
+
+        # Send command via shared memory (MCP server attaches to Canvas's memory)
+        shm_manager = SharedMemoryManager(name_prefix=f"canvas_{canvas_id}")
+        try:
+            shm_manager.attach_regions()
+
+            # Write command (fire-and-forget)
+            seq_num = shm_manager.write_command(
+                CommandType.CLEAR_CANVAS, canvas_id=canvas_id
+            )
+
+            logger.info(f"Sent CLEAR_CANVAS command to '{canvas_id}' (seq={seq_num})")
+
+            return {
+                "success": True,
+                "data": {
+                    "canvas_id": canvas_id,
+                    "command": "CLEAR_CANVAS",
+                    "seq_num": seq_num,
+                },
+            }
+
+        finally:
+            # Clean up shared memory handle (Canvas owns the memory)
+            shm_manager.cleanup()
+
+    except Exception as e:
+        logger.error(f"Error clearing canvas '{canvas_id}': {e}")
+        return {
+            "success": False,
+            "error": str(e),
+        }
+
+
+@mcp.tool()
+def list_canvases() -> dict[str, Any]:
+    """List all active canvas IDs.
+
+    Returns:
+        Success status and list of canvas IDs
+    """
+    try:
+        canvas_ids = canvas_manager.list_canvases()
+
+        return {
+            "success": True,
+            "data": {
+                "canvas_ids": canvas_ids,
+                "count": len(canvas_ids),
+            },
+        }
+
+    except Exception as e:
+        logger.error(f"Error listing canvases: {e}")
+        return {
+            "success": False,
+            "error": str(e),
+        }
+
+
+@mcp.tool()
+def update_canvas_state(
+    canvas_id: str,
+    title: str | None = None,
+    width: int | None = None,
+    height: int | None = None,
+) -> dict[str, Any]:
+    """Update canvas state (title, size).
+
+    Sends an UPDATE_STATE command via shared memory to the canvas render thread.
+
+    Args:
+        canvas_id: Canvas identifier
+        title: New window title (optional)
+        width: New window width in pixels (optional)
+        height: New window height in pixels (optional)
+
+    Returns:
+        Success status
+    """
+    try:
+        canvas = canvas_manager.get_canvas(canvas_id)
+        if canvas is None:
+            return {
+                "success": False,
+                "error": f"Canvas '{canvas_id}' not found",
+            }
+
+        # Ensure canvas is running
+        if not canvas._running:
+            canvas.run_async()
+
+        # Prepare command data
+        cmd_data: dict[str, Any] = {"canvas_id": canvas_id}
+        if title is not None:
+            cmd_data["title"] = title
+        if width is not None:
+            cmd_data["width"] = width
+        if height is not None:
+            cmd_data["height"] = height
+
+        # Send command via shared memory
+        shm_manager = SharedMemoryManager(name_prefix=f"canvas_{canvas_id}")
+        try:
+            shm_manager.attach_regions()
+
+            seq_num = shm_manager.write_command(CommandType.UPDATE_STATE, **cmd_data)
+
+            logger.info(f"Sent UPDATE_STATE command to '{canvas_id}' (seq={seq_num})")
+
+            return {
+                "success": True,
+                "data": {
+                    "canvas_id": canvas_id,
+                    "command": "UPDATE_STATE",
+                    "seq_num": seq_num,
+                    "updates": cmd_data,
+                },
+            }
+
+        finally:
+            shm_manager.cleanup()
+
+    except Exception as e:
+        logger.error(f"Error updating canvas state for '{canvas_id}': {e}")
+        return {
+            "success": False,
+            "error": str(e),
+        }
+
+
+@mcp.tool()
+def shutdown_canvas(canvas_id: str) -> dict[str, Any]:
+    """Shutdown a canvas window gracefully.
+
+    Sends a SHUTDOWN command via shared memory and removes canvas from manager.
+
+    Args:
+        canvas_id: Canvas identifier
+
+    Returns:
+        Success status
+    """
+    try:
+        canvas = canvas_manager.get_canvas(canvas_id)
+        if canvas is None:
+            return {
+                "success": False,
+                "error": f"Canvas '{canvas_id}' not found",
+            }
+
+        # Send shutdown command via shared memory
+        if canvas._running:
+            shm_manager = SharedMemoryManager(name_prefix=f"canvas_{canvas_id}")
+            try:
+                shm_manager.attach_regions()
+                seq_num = shm_manager.write_command(
+                    CommandType.SHUTDOWN, canvas_id=canvas_id
+                )
+                logger.info(f"Sent SHUTDOWN command to '{canvas_id}' (seq={seq_num})")
+            finally:
+                shm_manager.cleanup()
+
+        # Stop canvas and cleanup
+        canvas.stop()
+
+        # Remove from manager
+        del canvas_manager.canvases[canvas_id]
+
+        logger.info(f"Shutdown canvas '{canvas_id}'")
+
+        return {
+            "success": True,
+            "data": {"canvas_id": canvas_id, "shutdown": True},
+        }
+
+    except Exception as e:
+        logger.error(f"Error shutting down canvas '{canvas_id}': {e}")
+        return {
+            "success": False,
+            "error": str(e),
+        }


### PR DESCRIPTION
## Summary

Implements Stage 5 of the migration plan: Core Canvas System with Shared Memory IPC.

### Key Features

- **IPC Foundation**: Binary command structs with shared memory manager adapted from `mcp_champi/ipc_svc/`
- **Canvas with Event-Driven Rendering**: Background thread processes commands asynchronously
- **CanvasManager**: Multi-canvas support with lifecycle management
- **MCP Server**: 6 tools for canvas operations (create, get state, clear, list, update, shutdown)
- **Fire-and-Forget IPC**: Asynchronous command processing via shared memory regions
- **CLI Entry Point**: Cleanup handlers for graceful shutdown

### Architecture

```
MCP Server Process ──[Shared Memory]──> Canvas Render Process
    (Producer)        (Command Queue)      (Consumer)
```

### MCP Tools

1. `create_canvas` - Create new canvas window
2. `get_canvas_state` - Get canvas state
3. `clear_canvas` - Clear all widgets
4. `list_canvases` - List all canvas IDs
5. `update_canvas_state` - Update canvas properties
6. `shutdown_canvas` - Gracefully shutdown canvas

### Testing

- ✅ All pre-commit hooks passed
- ✅ Ruff linter and formatter
- ✅ MyPy type checking
- ✅ Pytest (1 test passed, 100%)
- ✅ Detect secrets

### Version Bump

This `feat:` commit with `BREAKING CHANGE:` will trigger version bump from **v0.0.3 → v0.1.0** when merged to main.

### Next Steps

- Merge to main to trigger automated release
- Stage 6: Widget library implementation (v0.1.0 → v0.2.0)