### PR TITLE
fix: make version test dynamic to prevent failures on releases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
 
   # Ruff for linting and formatting
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.4
+    rev: v0.14.2
     hooks:
       - id: ruff
         args: [--fix]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,8 +1,18 @@
 """Test package version."""
 
+import re
+
 from champi_imgui import __version__
 
 
 def test_version():
-    """Test that version is set."""
-    assert __version__ == "0.0.3"
+    """Test that version is set and follows semver format."""
+    # Check version exists and is not empty
+    assert __version__
+    assert isinstance(__version__, str)
+
+    # Check version follows semver pattern (major.minor.patch)
+    semver_pattern = r"^\d+\.\d+\.\d+$"
+    assert re.match(
+        semver_pattern, __version__
+    ), f"Version '{__version__}' does not match semver format"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -13,6 +13,6 @@ def test_version():
 
     # Check version follows semver pattern (major.minor.patch)
     semver_pattern = r"^\d+\.\d+\.\d+$"
-    assert re.match(
-        semver_pattern, __version__
-    ), f"Version '{__version__}' does not match semver format"
+    assert re.match(semver_pattern, __version__), (
+        f"Version '{__version__}' does not match semver format"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -159,7 +159,7 @@ wheels = [
 
 [[package]]
 name = "champi-imgui"
-version = "0.0.3"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "blinker" },


### PR DESCRIPTION
## Problem

The version test was hardcoded to check for a specific version (e.g., `0.0.3`), which causes CI failures every time the automated release workflow bumps the version.

## Solution

Changed the test to validate:
1. Version exists and is not empty
2. Version is a string
3. Version follows semver pattern (major.minor.patch format using regex)

## Testing

✅ Test passes with current version (1.0.0)
✅ Test will pass with any valid semver version
✅ All pre-commit hooks pass

## Impact

This fix prevents CI failures on every automated release, making the release workflow more reliable.