### PR TITLE
feat: merge core widget system into main

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,535 @@
+# Champi-Gen-UI Architecture
+
+## System Overview
+
+Champi-Gen-UI is an MCP (Model Context Protocol) server that bridges LLMs with ImGui for generative UI creation. It provides 200+ tools for creating, manipulating, and rendering UI elements through natural language.
+
+---
+
+## Core Components
+
+### 1. MCP Server Layer
+```
+┌─────────────────────────────────────────┐
+│         FastMCP Server                   │
+│  ┌─────────────────────────────────┐   │
+│  │   Tool Registry (200+ tools)    │   │
+│  └─────────────────────────────────┘   │
+│  ┌─────────────────────────────────┐   │
+│  │   Request Handler               │   │
+│  └─────────────────────────────────┘   │
+│  ┌─────────────────────────────────┐   │
+│  │   Response Serializer           │   │
+│  └─────────────────────────────────┘   │
+└─────────────────────────────────────────┘
+           │
+           ▼
+┌─────────────────────────────────────────┐
+│      Canvas Manager                      │
+│  ┌─────────────────────────────────┐   │
+│  │   Canvas Registry               │   │
+│  │   Canvas State Store            │   │
+│  │   Rendering Pipeline            │   │
+│  └─────────────────────────────────┘   │
+└─────────────────────────────────────────┘
+           │
+           ▼
+┌─────────────────────────────────────────┐
+│      Widget System                       │
+│  ┌─────────────────────────────────┐   │
+│  │   Widget Registry               │   │
+│  │   Widget Factory                │   │
+│  │   Widget State Manager          │   │
+│  └─────────────────────────────────┘   │
+└─────────────────────────────────────────┘
+           │
+           ▼
+┌─────────────────────────────────────────┐
+│      ImGui Bundle                        │
+│  ┌─────────────────────────────────┐   │
+│  │   imgui (core)                  │   │
+│  │   immapp (application)          │   │
+│  │   ImPlot (plotting)             │   │
+│  │   Extensions                    │   │
+│  └─────────────────────────────────┘   │
+└─────────────────────────────────────────┘
+```
+
+---
+
+## 2. Data Flow
+
+### Request Flow
+```
+LLM → MCP Client → FastMCP Server → Tool Handler → Canvas Manager → Widget System → ImGui
+```
+
+### Response Flow
+```
+ImGui → Widget State → Canvas State → Serializer → FastMCP Server → MCP Client → LLM
+```
+
+### Render Loop
+```
+Main Thread:
+  ├─ Process MCP Commands (from queue)
+  ├─ Update Widget States
+  ├─ Run ImGui Frame
+  │   ├─ Begin Frame
+  │   ├─ Render Widgets
+  │   ├─ Handle Input
+  │   └─ End Frame
+  └─ Swap Buffers
+
+Worker Threads:
+  ├─ MCP Request Handler
+  ├─ Command Queue Writer
+  └─ State Synchronizer
+```
+
+---
+
+## 3. State Management
+
+### Canvas State
+```python
+@dataclass
+class CanvasState:
+    canvas_id: str
+    mode: CanvasMode  # standard, docking, multi_viewport, fullscreen, overlay
+    size: tuple[int, int]
+    position: tuple[int, int]
+    theme: str
+    widgets: dict[str, WidgetState]
+    layout: LayoutState
+    style: StyleState
+    active: bool
+```
+
+### Widget State
+```python
+@dataclass
+class WidgetState:
+    widget_id: str
+    widget_type: str
+    properties: dict[str, Any]
+    position: tuple[float, float]
+    size: tuple[float, float]
+    visible: bool
+    enabled: bool
+    parent: Optional[str]
+    children: list[str]
+    callbacks: dict[str, str]
+    data_bindings: dict[str, DataBinding]
+```
+
+### Signal-Based Updates
+Uses `blinker` for event-driven state propagation:
+
+```python
+# Signals
+widget_created = blinker.signal('widget-created')
+widget_updated = blinker.signal('widget-updated')
+widget_deleted = blinker.signal('widget-deleted')
+canvas_updated = blinker.signal('canvas-updated')
+state_changed = blinker.signal('state-changed')
+```
+
+---
+
+## 4. Threading Model
+
+### Thread Architecture
+```
+┌─────────────────────────────────────────┐
+│           Main Thread                    │
+│  - ImGui Rendering                       │
+│  - Input Handling                        │
+│  - Command Processing                    │
+│  - State Updates                         │
+└─────────────────────────────────────────┘
+           ▲         │
+     Commands    State Updates
+           │         ▼
+┌─────────────────────────────────────────┐
+│         Worker Thread Pool               │
+│  - MCP Request Handling                  │
+│  - Tool Execution                        │
+│  - Data Processing                       │
+│  - Background Tasks                      │
+└─────────────────────────────────────────┘
+```
+
+### Thread-Safe Communication
+```python
+# Command queue (worker → main)
+command_queue = Queue()
+
+# State queue (main → worker)
+state_queue = Queue()
+
+# Thread-safe state access
+state_lock = threading.RLock()
+```
+
+---
+
+## 5. Widget System Architecture
+
+### Widget Factory Pattern
+```python
+class WidgetFactory:
+    def __init__(self):
+        self._creators: dict[str, Callable] = {}
+
+    def register(self, widget_type: str, creator: Callable):
+        self._creators[widget_type] = creator
+
+    def create(self, widget_type: str, **props) -> Widget:
+        creator = self._creators.get(widget_type)
+        if not creator:
+            raise ValueError(f"Unknown widget type: {widget_type}")
+        return creator(**props)
+
+# Registration
+factory = WidgetFactory()
+factory.register("button", ButtonWidget)
+factory.register("text", TextWidget)
+factory.register("slider", SliderWidget)
+```
+
+### Widget Base Class
+```python
+class Widget(ABC):
+    def __init__(self, widget_id: str, **props):
+        self.widget_id = widget_id
+        self.properties = props
+        self.state = WidgetState(...)
+
+    @abstractmethod
+    def render(self):
+        """Render the widget using ImGui calls"""
+        pass
+
+    @abstractmethod
+    def update(self, **props):
+        """Update widget properties"""
+        pass
+
+    def serialize(self) -> dict:
+        """Serialize widget state to JSON"""
+        return self.state.__dict__
+```
+
+---
+
+## 6. Canvas System Architecture
+
+### Canvas Manager
+```python
+class CanvasManager:
+    def __init__(self):
+        self.canvases: dict[str, Canvas] = {}
+        self.active_canvas: Optional[str] = None
+
+    def create_canvas(self, canvas_id: str, **props) -> Canvas:
+        canvas = Canvas(canvas_id, **props)
+        self.canvases[canvas_id] = canvas
+        return canvas
+
+    def get_canvas(self, canvas_id: str) -> Canvas:
+        return self.canvases.get(canvas_id)
+
+    def render_all(self):
+        for canvas in self.canvases.values():
+            if canvas.active:
+                canvas.render()
+```
+
+### Canvas Class
+```python
+class Canvas:
+    def __init__(self, canvas_id: str, **props):
+        self.canvas_id = canvas_id
+        self.widgets: dict[str, Widget] = {}
+        self.layout_manager = LayoutManager()
+        self.state = CanvasState(...)
+
+    def add_widget(self, widget: Widget):
+        self.widgets[widget.widget_id] = widget
+        widget_created.send(self, widget=widget)
+
+    def render(self):
+        """Render all widgets on this canvas"""
+        imgui.begin(self.state.title)
+        for widget in self.widgets.values():
+            if widget.state.visible:
+                widget.render()
+        imgui.end()
+```
+
+---
+
+## 7. Extension Integration
+
+### Extension Registry
+```python
+class ExtensionRegistry:
+    def __init__(self):
+        self.extensions: dict[str, Extension] = {}
+
+    def register(self, name: str, extension: Extension):
+        self.extensions[name] = extension
+        extension.initialize()
+
+    def get(self, name: str) -> Extension:
+        return self.extensions.get(name)
+
+# Extensions
+registry = ExtensionRegistry()
+registry.register("implot", ImPlotExtension())
+registry.register("node_editor", NodeEditorExtension())
+registry.register("text_editor", TextEditorExtension())
+registry.register("file_dialog", FileDialogExtension())
+registry.register("notifications", NotificationExtension())
+```
+
+### Extension Base Class
+```python
+class Extension(ABC):
+    @abstractmethod
+    def initialize(self):
+        """Initialize extension"""
+        pass
+
+    @abstractmethod
+    def register_tools(self, server: FastMCP):
+        """Register MCP tools"""
+        pass
+
+    @abstractmethod
+    def render(self):
+        """Render extension UI"""
+        pass
+```
+
+---
+
+## 8. Animation System
+
+### Animation Engine
+```python
+class AnimationEngine:
+    def __init__(self):
+        self.animations: dict[str, Animation] = {}
+        self.current_frame = 0
+
+    def create_animation(self, anim_id: str, keyframes: list, values: list, easing: str):
+        animation = Animation(anim_id, keyframes, values, easing)
+        self.animations[anim_id] = animation
+
+    def update(self, delta_time: float):
+        self.current_frame += delta_time * 60  # Assume 60 FPS
+        for animation in self.animations.values():
+            if animation.playing:
+                animation.update(self.current_frame)
+
+    def get_value(self, anim_id: str) -> float:
+        animation = self.animations.get(anim_id)
+        return animation.get_interpolated_value() if animation else 0.0
+```
+
+### Animation Class
+```python
+class Animation:
+    def __init__(self, anim_id: str, keyframes: list, values: list, easing: str):
+        self.anim_id = anim_id
+        self.keyframes = keyframes
+        self.values = values
+        self.easing = EasingFunction.get(easing)
+        self.playing = False
+        self.current_value = values[0]
+
+    def get_interpolated_value(self) -> float:
+        # Find surrounding keyframes
+        # Apply easing function
+        # Return interpolated value
+        pass
+```
+
+---
+
+## 9. Data Binding System
+
+### Data Binding Architecture
+```python
+class DataBindingManager:
+    def __init__(self):
+        self.bindings: dict[str, DataBinding] = {}
+
+    def bind(self, widget_id: str, property: str, data_source: DataSource):
+        binding = DataBinding(widget_id, property, data_source)
+        self.bindings[f"{widget_id}.{property}"] = binding
+        data_source.on_change(lambda value: self.update_widget(widget_id, property, value))
+
+    def update_widget(self, widget_id: str, property: str, value: Any):
+        # Update widget with new value
+        state_changed.send(self, widget_id=widget_id, property=property, value=value)
+```
+
+---
+
+## 10. Serialization Format
+
+### Canvas JSON Format
+```json
+{
+  "version": "1.0",
+  "canvas": {
+    "canvas_id": "main_canvas",
+    "mode": "standard",
+    "size": [1280, 720],
+    "position": [0, 0],
+    "theme": "dark",
+    "title": "My UI"
+  },
+  "widgets": [
+    {
+      "widget_id": "btn1",
+      "type": "button",
+      "properties": {
+        "label": "Click Me",
+        "position": [10, 10],
+        "size": [100, 30]
+      },
+      "callbacks": {
+        "on_click": "handle_click"
+      }
+    },
+    {
+      "widget_id": "slider1",
+      "type": "slider_float",
+      "properties": {
+        "label": "Volume",
+        "value": 0.5,
+        "min": 0.0,
+        "max": 1.0,
+        "position": [10, 50]
+      },
+      "data_bindings": {
+        "value": "audio.volume"
+      }
+    }
+  ],
+  "layout": {
+    "type": "vertical",
+    "spacing": 5,
+    "padding": 10
+  }
+}
+```
+
+---
+
+## 11. Error Handling
+
+### Error Hierarchy
+```python
+class ChampiGenUIError(Exception):
+    """Base exception"""
+    pass
+
+class CanvasError(ChampiGenUIError):
+    """Canvas-related errors"""
+    pass
+
+class WidgetError(ChampiGenUIError):
+    """Widget-related errors"""
+    pass
+
+class ToolError(ChampiGenUIError):
+    """MCP tool execution errors"""
+    pass
+```
+
+### Error Recovery
+- Graceful degradation for missing widgets
+- State rollback on failed operations
+- Error reporting through MCP responses
+
+---
+
+## 12. Performance Considerations
+
+### Optimization Strategies
+1. **Widget Pooling**: Reuse widget objects
+2. **Lazy Rendering**: Only render visible widgets
+3. **State Diffing**: Only update changed properties
+4. **Command Batching**: Batch multiple MCP commands
+5. **Async Operations**: Non-blocking tool execution
+
+### Memory Management
+- Automatic cleanup of deleted widgets
+- Canvas destruction clears all resources
+- Texture caching for images
+
+---
+
+## 13. Testing Architecture
+
+### Test Structure
+```
+tests/
+├── unit/
+│   ├── test_widgets.py
+│   ├── test_canvas.py
+│   ├── test_layout.py
+│   └── test_animation.py
+├── integration/
+│   ├── test_mcp_tools.py
+│   ├── test_extensions.py
+│   └── test_serialization.py
+└── visual/
+    ├── test_rendering.py
+    └── test_themes.py
+```
+
+---
+
+## 14. Deployment Architecture
+
+### MCP Server Configuration
+```json
+{
+  "mcpServers": {
+    "champi-gen-ui": {
+      "command": "uv",
+      "args": ["run", "champi-gen-ui", "serve"],
+      "cwd": "/path/to/champi-gen-ui",
+      "env": {
+        "DISPLAY": ":0"
+      }
+    }
+  }
+}
+```
+
+### Server Entry Point
+```python
+# src/champi_gen_ui/server/main.py
+from fastmcp import FastMCP
+
+mcp = FastMCP("champi-gen-ui")
+
+# Register all tools
+register_canvas_tools(mcp)
+register_widget_tools(mcp)
+register_extension_tools(mcp)
+
+if __name__ == "__main__":
+    mcp.run()
+```
+
+---
+
+This architecture provides a scalable, extensible foundation for generative UI creation through LLMs using ImGui and the MCP protocol.

--- a/docs/EXTENSIONS_GUIDE.md
+++ b/docs/EXTENSIONS_GUIDE.md
@@ -1,0 +1,458 @@
+# Extensions Guide - Third-Party ImGui Extensions
+
+## 1. ImGui Club Extensions
+
+### 1.1 Memory Editor
+**Repository**: https://github.com/ocornut/imgui_club
+
+**Features**:
+- Mini hexadecimal editor
+- Keyboard navigation
+- Read-only mode option
+- ASCII/HexII display
+- Goto address functionality
+- Highlight range/function
+- Read/Write handlers
+- Right-click option menu
+
+**MCP Tools**:
+```python
+# Create memory editor
+add_memory_editor(
+    data: bytes,
+    size: int,
+    base_address: int = 0,
+    read_only: bool = False
+)
+
+# Configure display
+set_memory_display_format(
+    show_ascii: bool = True,
+    show_hexii: bool = False,
+    columns: int = 16
+)
+
+# Highlight operations
+highlight_memory_range(
+    start: int,
+    end: int,
+    color: tuple
+)
+```
+
+### 1.2 Multi-Context Compositor
+**Features**:
+- Manage multiple ImGui contexts
+- Z-order management
+- Input routing between contexts
+- Drag and drop between contexts
+
+**MCP Tools**:
+```python
+# Context management
+create_imgui_context(name: str)
+switch_context(name: str)
+set_context_z_order(name: str, z_order: int)
+enable_context_drag_drop()
+```
+
+### 1.3 Threaded Rendering
+**Features**:
+- Snapshot ImDrawData for async rendering
+- Thread-safe rendering pipeline
+
+**MCP Tools**:
+```python
+# Threaded operations
+capture_draw_data()
+render_async(draw_data: DrawData)
+```
+
+---
+
+## 2. Animation System (HImGuiAnimation)
+
+### 2.1 Core Animation Features
+**Repository**: https://github.com/Half-People/HImGuiAnimation
+
+**Capabilities**:
+- Keyframe-based animation
+- Linear interpolation
+- Minimal code implementation (<10 lines)
+- No external dependencies
+- Numeric value animation
+
+**MCP Tools**:
+```python
+# Create animation sequence
+create_animation(
+    keyframes: list[int],      # Frame numbers
+    values: list[float],        # Corresponding values
+    name: str
+)
+
+# Interpolation
+animate_value(
+    animation_name: str,
+    current_frame: int,
+    easing: str = "linear"      # linear, ease_in, ease_out, etc.
+)
+
+# Playback control
+play_animation(name: str, fps: int = 60)
+pause_animation(name: str)
+stop_animation(name: str)
+set_animation_loop(name: str, loop: bool)
+
+# Easing functions
+set_easing_function(
+    animation_name: str,
+    easing: str  # linear, cubic, bounce, elastic, etc.
+)
+```
+
+**Example**:
+```python
+# Animate button position
+animation = create_animation(
+    keyframes=[0, 30, 64],
+    values=[80, 200, 80],
+    name="button_x"
+)
+
+# In render loop
+x_pos = animate_value("button_x", current_frame)
+```
+
+---
+
+## 3. File Dialogs
+
+### 3.1 ImGuiFD
+**Repository**: https://github.com/Julianiolo/ImGuiFD
+
+**Features**:
+- No external dependencies (no STL)
+- Directory selection
+- ImGui-like API
+- Lightweight implementation
+
+**MCP Tools**:
+```python
+# File operations
+open_file_dialog(
+    title: str = "Open File",
+    initial_path: str = ".",
+    filters: list[str] = []
+)
+
+open_dir_dialog(
+    title: str = "Select Directory",
+    initial_path: str = "."
+)
+
+save_file_dialog(
+    title: str = "Save File",
+    initial_path: str = ".",
+    default_name: str = "untitled"
+)
+
+# Dialog state
+is_dialog_open() -> bool
+get_selected_path() -> str
+close_dialog()
+```
+
+### 3.2 imfile (Rust-based alternative)
+**Repository**: https://github.com/tseli0s/imfile
+
+**Features**:
+- Embedded file browser
+- Compatible with imgui-rs >= 0.11.0
+- Configurable dialogs
+- Directory-only mode
+
+**MCP Tools**:
+```python
+# Advanced file dialog
+create_file_dialog(
+    mode: str,              # "open", "save"
+    title: str = "File",
+    accept_text: str = "OK",
+    dir_only: bool = False
+)
+
+set_file_filters(filters: list[str])
+```
+
+---
+
+## 4. Notifications (imgui-notify)
+
+### 4.1 Toast Notifications
+**Repository**: https://github.com/patrickcjk/imgui-notify
+
+**Features**:
+- Header-only C++ library
+- Multiple notification types
+- Font Awesome 5 icons
+- Customizable duration
+- Formatted content
+- Multiline support
+- Styling options
+
+**MCP Tools**:
+```python
+# Notification types
+show_notification(
+    type: str,              # success, warning, error, info
+    message: str,
+    title: str = None,
+    duration: int = 3000    # milliseconds
+)
+
+show_success(message: str, duration: int = 3000)
+show_warning(message: str, duration: int = 3000)
+show_error(message: str, duration: int = 3000)
+show_info(message: str, duration: int = 3000)
+
+# Configuration
+set_notification_position(
+    position: str  # top_left, top_right, bottom_left, bottom_right
+)
+
+set_notification_style(
+    rounded: bool = True,
+    background_alpha: float = 0.9
+)
+
+# Management
+clear_notifications()
+clear_notification_type(type: str)
+```
+
+---
+
+## 5. Useful Widgets Collection
+
+### 5.1 From ImGui Issues & Wiki
+**Source**: https://github.com/ocornut/imgui/labels/useful%20widgets
+
+**Available Widgets**:
+
+1. **ImagePolygonButton**: Button with custom polygon shape
+2. **Box Component**: Generic container widget
+3. **Gradient Widgets**: Color gradient editors
+4. **Texture Inspector**: ImGuiTexInspect for texture viewing
+5. **Markdown Renderer**: imgui_md for markdown display
+6. **Slider2D/3D**: Multi-dimensional sliders
+7. **Spin Input**: Numeric spinners
+8. **Editable Selectable**: Selectable with inline editing
+9. **Pie Menu**: Radial menu system
+
+**MCP Tools**:
+```python
+# Gradient editor
+add_gradient_editor(
+    id: str,
+    gradient_stops: list[tuple[float, tuple]]  # [(position, color), ...]
+)
+
+# 2D/3D Sliders
+add_slider_2d(
+    label: str,
+    value: tuple[float, float],
+    min_val: tuple[float, float],
+    max_val: tuple[float, float]
+)
+
+add_slider_3d(
+    label: str,
+    value: tuple[float, float, float],
+    min_val: tuple[float, float, float],
+    max_val: tuple[float, float, float]
+)
+
+# Spin input
+add_spin_input(
+    label: str,
+    value: float,
+    step: float = 1.0,
+    step_fast: float = 10.0
+)
+
+# Pie menu
+create_pie_menu(
+    id: str,
+    items: list[str],
+    radius: float = 100.0
+)
+```
+
+---
+
+## 6. Advanced Extensions
+
+### 6.1 Node Editors
+- **ImNodes**: Node graph editing
+- **imnodes**: Alternative implementation
+
+**MCP Tools**:
+```python
+# Node editor
+create_node_editor(id: str, style: str = "default")
+
+# Node operations
+add_node(
+    editor_id: str,
+    node_id: str,
+    title: str,
+    pos: tuple[float, float] = None
+)
+
+add_node_input(node_id: str, pin_id: str, label: str)
+add_node_output(node_id: str, pin_id: str, label: str)
+
+# Connections
+add_link(
+    editor_id: str,
+    from_pin: str,
+    to_pin: str
+)
+
+get_node_connections(editor_id: str) -> list
+```
+
+### 6.2 Text Editors
+- **ImGuiColorTextEdit**: Syntax-highlighted editor
+- **imgui-markdown**: Markdown rendering
+
+**MCP Tools**:
+```python
+# Code editor
+create_code_editor(
+    id: str,
+    language: str = "python",  # python, cpp, js, etc.
+    read_only: bool = False
+)
+
+set_editor_text(editor_id: str, text: str)
+get_editor_text(editor_id: str) -> str
+set_syntax_highlighting(editor_id: str, enabled: bool)
+
+# Markdown
+render_markdown(
+    text: str,
+    font_size: int = 14
+)
+```
+
+### 6.3 Plotting Extensions
+**ImPlot Integration**
+
+**MCP Tools**:
+```python
+# Advanced plots
+add_heatmap(
+    data: list[list[float]],
+    label: str,
+    scale_min: float,
+    scale_max: float
+)
+
+add_candlestick_chart(
+    dates: list,
+    opens: list,
+    highs: list,
+    lows: list,
+    closes: list
+)
+
+add_3d_surface(
+    x: list,
+    y: list,
+    z: list[list],
+    label: str
+)
+```
+
+---
+
+## 7. Custom Widget Extensions
+
+### 7.1 Knobs
+**Features**: Rotary control widgets
+
+**MCP Tools**:
+```python
+add_knob(
+    label: str,
+    value: float,
+    min_val: float,
+    max_val: float,
+    size: float = 40.0,
+    style: str = "wiper"  # wiper, dot, stepped
+)
+```
+
+### 7.2 Toggles
+**Features**: Modern toggle switches
+
+**MCP Tools**:
+```python
+add_toggle(
+    label: str,
+    value: bool,
+    size: tuple[float, float] = (40, 20),
+    animated: bool = True
+)
+```
+
+### 7.3 Spinners
+**Features**: Loading indicators
+
+**MCP Tools**:
+```python
+add_spinner(
+    type: str,  # circular, dots, bars, bounce
+    size: float = 30.0,
+    color: tuple = None
+)
+```
+
+### 7.4 Date/Time Pickers
+**MCP Tools**:
+```python
+add_date_picker(
+    label: str,
+    date: str = "today",  # YYYY-MM-DD
+    format: str = "%Y-%m-%d"
+)
+
+add_time_picker(
+    label: str,
+    time: str = "now",  # HH:MM:SS
+    format: str = "%H:%M:%S",
+    show_seconds: bool = True
+)
+```
+
+---
+
+## 8. Integration Summary
+
+### Total Extensions Covered:
+1. ✅ imgui_club (3 extensions)
+2. ✅ HImGuiAnimation (animation system)
+3. ✅ ImGuiFD (file dialogs)
+4. ✅ imfile (file browser)
+5. ✅ imgui-notify (notifications)
+6. ✅ Useful widgets collection (9+ widgets)
+7. ✅ Node editors (2 implementations)
+8. ✅ Text/code editors (2 types)
+9. ✅ ImPlot (plotting library)
+10. ✅ Custom widgets (knobs, toggles, spinners, pickers)
+
+### MCP Tool Count from Extensions: 80+
+
+All extensions will be accessible through the MCP server tools, allowing LLMs to create sophisticated UIs with rich functionality.

--- a/docs/IMGUI_CORE_REFERENCE.md
+++ b/docs/IMGUI_CORE_REFERENCE.md
@@ -1,0 +1,470 @@
+# ImGui Core Reference - Complete UI Element Lists
+
+## 1. Basic Widgets
+
+### 1.1 Buttons
+```python
+# Standard buttons
+imgui.button(label: str, size: ImVec2 = (0,0)) -> bool
+imgui.small_button(label: str) -> bool
+imgui.invisible_button(str_id: str, size: ImVec2, flags: int = 0) -> bool
+imgui.arrow_button(str_id: str, dir: int) -> bool
+imgui.checkbox(label: str, v: bool) -> tuple[bool, bool]
+imgui.radio_button(label: str, active: bool) -> bool
+```
+
+### 1.2 Text
+```python
+imgui.text(text: str)
+imgui.text_colored(color: ImVec4, text: str)
+imgui.text_disabled(text: str)
+imgui.text_wrapped(text: str)
+imgui.label_text(label: str, text: str)
+imgui.bullet_text(text: str)
+imgui.bullet()
+```
+
+### 1.3 Input Text
+```python
+imgui.input_text(label: str, text: str, flags: int = 0) -> tuple[bool, str]
+imgui.input_text_multiline(label: str, text: str, size: ImVec2, flags: int = 0) -> tuple[bool, str]
+imgui.input_text_with_hint(label: str, hint: str, text: str, flags: int = 0) -> tuple[bool, str]
+```
+
+### 1.4 Input Numbers
+```python
+imgui.input_int(label: str, v: int, step: int = 1, step_fast: int = 100, flags: int = 0) -> tuple[bool, int]
+imgui.input_float(label: str, v: float, step: float = 0, step_fast: float = 0, format: str = "%.3f", flags: int = 0) -> tuple[bool, float]
+imgui.input_double(label: str, v: float, step: float = 0, step_fast: float = 0, format: str = "%.6f", flags: int = 0) -> tuple[bool, float]
+imgui.input_scalar(label: str, data_type: int, p_data, p_step, p_step_fast, format: str, flags: int = 0)
+```
+
+---
+
+## 2. Sliders & Drags
+
+### 2.1 Sliders
+```python
+# Integer sliders
+imgui.slider_int(label: str, v: int, v_min: int, v_max: int, format: str = "%d", flags: int = 0) -> tuple[bool, int]
+imgui.slider_int2(label: str, v: list, v_min: int, v_max: int, format: str = "%d", flags: int = 0) -> tuple[bool, list]
+imgui.slider_int3(label: str, v: list, v_min: int, v_max: int, format: str = "%d", flags: int = 0) -> tuple[bool, list]
+imgui.slider_int4(label: str, v: list, v_min: int, v_max: int, format: str = "%d", flags: int = 0) -> tuple[bool, list]
+
+# Float sliders
+imgui.slider_float(label: str, v: float, v_min: float, v_max: float, format: str = "%.3f", flags: int = 0) -> tuple[bool, float]
+imgui.slider_float2(label: str, v: list, v_min: float, v_max: float, format: str = "%.3f", flags: int = 0) -> tuple[bool, list]
+imgui.slider_float3(label: str, v: list, v_min: float, v_max: float, format: str = "%.3f", flags: int = 0) -> tuple[bool, list]
+imgui.slider_float4(label: str, v: list, v_min: float, v_max: float, format: str = "%.3f", flags: int = 0) -> tuple[bool, list]
+
+# Special sliders
+imgui.slider_angle(label: str, v_rad: float, v_degrees_min: float = -360, v_degrees_max: float = 360, format: str = "%.0f deg", flags: int = 0) -> tuple[bool, float]
+imgui.v_slider_int(label: str, size: ImVec2, v: int, v_min: int, v_max: int, format: str = "%d", flags: int = 0) -> tuple[bool, int]
+imgui.v_slider_float(label: str, size: ImVec2, v: float, v_min: float, v_max: float, format: str = "%.3f", flags: int = 0) -> tuple[bool, float]
+```
+
+### 2.2 Drag Controls
+```python
+# Integer drag
+imgui.drag_int(label: str, v: int, v_speed: float = 1.0, v_min: int = 0, v_max: int = 0, format: str = "%d", flags: int = 0) -> tuple[bool, int]
+imgui.drag_int2(label: str, v: list, v_speed: float = 1.0, v_min: int = 0, v_max: int = 0, format: str = "%d", flags: int = 0) -> tuple[bool, list]
+imgui.drag_int3(label: str, v: list, v_speed: float = 1.0, v_min: int = 0, v_max: int = 0, format: str = "%d", flags: int = 0) -> tuple[bool, list]
+imgui.drag_int4(label: str, v: list, v_speed: float = 1.0, v_min: int = 0, v_max: int = 0, format: str = "%d", flags: int = 0) -> tuple[bool, list]
+
+# Float drag
+imgui.drag_float(label: str, v: float, v_speed: float = 1.0, v_min: float = 0, v_max: float = 0, format: str = "%.3f", flags: int = 0) -> tuple[bool, float]
+imgui.drag_float2(label: str, v: list, v_speed: float = 1.0, v_min: float = 0, v_max: float = 0, format: str = "%.3f", flags: int = 0) -> tuple[bool, list]
+imgui.drag_float3(label: str, v: list, v_speed: float = 1.0, v_min: float = 0, v_max: float = 0, format: str = "%.3f", flags: int = 0) -> tuple[bool, list]
+imgui.drag_float4(label: str, v: list, v_speed: float = 1.0, v_min: float = 0, v_max: float = 0, format: str = "%.3f", flags: int = 0) -> tuple[bool, list]
+
+# Range drag
+imgui.drag_float_range2(label: str, v_current_min: float, v_current_max: float, v_speed: float = 1.0, v_min: float = 0, v_max: float = 0, format: str = "%.3f", format_max: str = None, flags: int = 0)
+imgui.drag_int_range2(label: str, v_current_min: int, v_current_max: int, v_speed: float = 1.0, v_min: int = 0, v_max: int = 0, format: str = "%d", format_max: str = None, flags: int = 0)
+```
+
+---
+
+## 3. Color Widgets
+
+```python
+# Color edit
+imgui.color_edit3(label: str, col: tuple[float, float, float], flags: int = 0) -> tuple[bool, tuple]
+imgui.color_edit4(label: str, col: tuple[float, float, float, float], flags: int = 0) -> tuple[bool, tuple]
+
+# Color picker
+imgui.color_picker3(label: str, col: tuple[float, float, float], flags: int = 0) -> tuple[bool, tuple]
+imgui.color_picker4(label: str, col: tuple[float, float, float, float], flags: int = 0, ref_col: tuple = None) -> tuple[bool, tuple]
+
+# Color button
+imgui.color_button(desc_id: str, col: ImVec4, flags: int = 0, size: ImVec2 = (0,0)) -> bool
+```
+
+---
+
+## 4. Combo & Lists
+
+```python
+# Combo box
+imgui.combo(label: str, current_item: int, items: list[str], popup_max_height_in_items: int = -1) -> tuple[bool, int]
+imgui.begin_combo(label: str, preview_value: str, flags: int = 0) -> bool
+imgui.end_combo()
+
+# List box
+imgui.list_box(label: str, current_item: int, items: list[str], height_in_items: int = -1) -> tuple[bool, int]
+imgui.begin_list_box(label: str, size: ImVec2 = (0,0)) -> bool
+imgui.end_list_box()
+
+# Selectable
+imgui.selectable(label: str, selected: bool = False, flags: int = 0, size: ImVec2 = (0,0)) -> tuple[bool, bool]
+```
+
+---
+
+## 5. Tree & Hierarchy
+
+```python
+# Tree nodes
+imgui.tree_node(label: str) -> bool
+imgui.tree_node_ex(label: str, flags: int = 0) -> bool
+imgui.tree_push(str_id: str)
+imgui.tree_pop()
+
+# Collapsing header
+imgui.collapsing_header(label: str, flags: int = 0) -> bool
+imgui.collapsing_header_with_close_button(label: str, visible: bool = True, flags: int = 0) -> tuple[bool, bool]
+
+# Indent
+imgui.indent(indent_w: float = 0.0)
+imgui.unindent(indent_w: float = 0.0)
+```
+
+---
+
+## 6. Tables (Advanced)
+
+```python
+# Table creation
+imgui.begin_table(str_id: str, column: int, flags: int = 0, outer_size: ImVec2 = (0,0), inner_width: float = 0.0) -> bool
+imgui.end_table()
+
+# Table columns
+imgui.table_next_row(row_flags: int = 0, min_row_height: float = 0.0)
+imgui.table_next_column() -> bool
+imgui.table_set_column_index(column_n: int) -> bool
+
+# Table setup
+imgui.table_setup_column(label: str, flags: int = 0, init_width_or_weight: float = 0.0, user_id: int = 0)
+imgui.table_setup_scroll_freeze(cols: int, rows: int)
+imgui.table_headers_row()
+imgui.table_header(label: str)
+
+# Table sorting
+imgui.table_get_sort_specs()
+imgui.table_get_column_count() -> int
+imgui.table_get_column_index() -> int
+imgui.table_get_row_index() -> int
+
+# Table background
+imgui.table_set_bg_color(target: int, color: int, column_n: int = -1)
+```
+
+---
+
+## 7. Menus
+
+```python
+# Menu bar
+imgui.begin_menu_bar() -> bool
+imgui.end_menu_bar()
+imgui.begin_main_menu_bar() -> bool
+imgui.end_main_menu_bar()
+
+# Menus
+imgui.begin_menu(label: str, enabled: bool = True) -> bool
+imgui.end_menu()
+imgui.menu_item(label: str, shortcut: str = None, selected: bool = False, enabled: bool = True) -> tuple[bool, bool]
+```
+
+---
+
+## 8. Tabs
+
+```python
+# Tab bar
+imgui.begin_tab_bar(str_id: str, flags: int = 0) -> bool
+imgui.end_tab_bar()
+
+# Tab items
+imgui.begin_tab_item(label: str, p_open: bool = None, flags: int = 0) -> tuple[bool, bool]
+imgui.end_tab_item()
+
+# Tab utilities
+imgui.tab_item_button(label: str, flags: int = 0) -> bool
+imgui.set_tab_item_closed(tab_or_docked_window_label: str)
+```
+
+---
+
+## 9. Windows & Child Windows
+
+```python
+# Main windows
+imgui.begin(name: str, closable: bool = None, flags: int = 0) -> tuple[bool, bool]
+imgui.end()
+
+# Child windows
+imgui.begin_child(str_id: str, size: ImVec2 = (0,0), border: bool = False, flags: int = 0) -> bool
+imgui.end_child()
+
+# Window utilities
+imgui.is_window_appearing() -> bool
+imgui.is_window_collapsed() -> bool
+imgui.is_window_focused(flags: int = 0) -> bool
+imgui.is_window_hovered(flags: int = 0) -> bool
+imgui.get_window_pos() -> ImVec2
+imgui.get_window_size() -> ImVec2
+imgui.get_window_width() -> float
+imgui.get_window_height() -> float
+```
+
+---
+
+## 10. Popups & Modals
+
+```python
+# Generic popups
+imgui.begin_popup(str_id: str, flags: int = 0) -> bool
+imgui.begin_popup_modal(name: str, p_open: bool = None, flags: int = 0) -> tuple[bool, bool]
+imgui.end_popup()
+imgui.open_popup(str_id: str, popup_flags: int = 0)
+imgui.close_current_popup()
+
+# Context menus
+imgui.begin_popup_context_item(str_id: str = None, popup_flags: int = 1) -> bool
+imgui.begin_popup_context_window(str_id: str = None, popup_flags: int = 1) -> bool
+imgui.begin_popup_context_void(str_id: str = None, popup_flags: int = 1) -> bool
+
+# Popup state
+imgui.is_popup_open(str_id: str, flags: int = 0) -> bool
+```
+
+---
+
+## 11. Tooltips
+
+```python
+imgui.begin_tooltip()
+imgui.end_tooltip()
+imgui.set_tooltip(text: str)
+imgui.set_tooltip_unformatted(text: str)
+```
+
+---
+
+## 12. Layout & Spacing
+
+```python
+# Cursor positioning
+imgui.separator()
+imgui.same_line(offset_from_start_x: float = 0.0, spacing: float = -1.0)
+imgui.new_line()
+imgui.spacing()
+imgui.dummy(size: ImVec2)
+
+# Alignment
+imgui.align_text_to_frame_padding()
+
+# Cursor manipulation
+imgui.get_cursor_pos() -> ImVec2
+imgui.get_cursor_pos_x() -> float
+imgui.get_cursor_pos_y() -> float
+imgui.set_cursor_pos(local_pos: ImVec2)
+imgui.set_cursor_pos_x(local_x: float)
+imgui.set_cursor_pos_y(local_y: float)
+imgui.get_cursor_start_pos() -> ImVec2
+imgui.get_cursor_screen_pos() -> ImVec2
+imgui.set_cursor_screen_pos(pos: ImVec2)
+
+# Item width
+imgui.push_item_width(item_width: float)
+imgui.pop_item_width()
+imgui.set_next_item_width(item_width: float)
+imgui.calc_item_width() -> float
+```
+
+---
+
+## 13. Groups
+
+```python
+imgui.begin_group()
+imgui.end_group()
+```
+
+---
+
+## 14. Drag & Drop
+
+```python
+# Drag source
+imgui.begin_drag_drop_source(flags: int = 0) -> bool
+imgui.set_drag_drop_payload(type: str, data: bytes, cond: int = 0) -> bool
+imgui.end_drag_drop_source()
+
+# Drop target
+imgui.begin_drag_drop_target() -> bool
+imgui.accept_drag_drop_payload(type: str, flags: int = 0)
+imgui.end_drag_drop_target()
+
+# Drag drop state
+imgui.get_drag_drop_payload()
+```
+
+---
+
+## 15. Progress & Loading
+
+```python
+imgui.progress_bar(fraction: float, size_arg: ImVec2 = (-1,0), overlay: str = None)
+```
+
+---
+
+## 16. Images & Textures
+
+```python
+imgui.image(user_texture_id, size: ImVec2, uv0: ImVec2 = (0,0), uv1: ImVec2 = (1,1), tint_col: ImVec4 = (1,1,1,1), border_col: ImVec4 = (0,0,0,0))
+imgui.image_button(user_texture_id, size: ImVec2, uv0: ImVec2 = (0,0), uv1: ImVec2 = (1,1), frame_padding: int = -1, bg_col: ImVec4 = (0,0,0,0), tint_col: ImVec4 = (1,1,1,1)) -> bool
+```
+
+---
+
+## 17. Drawing API (ImDrawList)
+
+```python
+# Get draw list
+draw_list = imgui.get_window_draw_list()
+draw_list = imgui.get_foreground_draw_list()
+draw_list = imgui.get_background_draw_list()
+
+# Primitives
+draw_list.add_line(p1: ImVec2, p2: ImVec2, col: int, thickness: float = 1.0)
+draw_list.add_rect(p_min: ImVec2, p_max: ImVec2, col: int, rounding: float = 0.0, flags: int = 0, thickness: float = 1.0)
+draw_list.add_rect_filled(p_min: ImVec2, p_max: ImVec2, col: int, rounding: float = 0.0, flags: int = 0)
+draw_list.add_quad(p1: ImVec2, p2: ImVec2, p3: ImVec2, p4: ImVec2, col: int, thickness: float = 1.0)
+draw_list.add_quad_filled(p1: ImVec2, p2: ImVec2, p3: ImVec2, p4: ImVec2, col: int)
+draw_list.add_triangle(p1: ImVec2, p2: ImVec2, p3: ImVec2, col: int, thickness: float = 1.0)
+draw_list.add_triangle_filled(p1: ImVec2, p2: ImVec2, p3: ImVec2, col: int)
+draw_list.add_circle(center: ImVec2, radius: float, col: int, num_segments: int = 0, thickness: float = 1.0)
+draw_list.add_circle_filled(center: ImVec2, radius: float, col: int, num_segments: int = 0)
+draw_list.add_ngon(center: ImVec2, radius: float, col: int, num_segments: int, thickness: float = 1.0)
+draw_list.add_ngon_filled(center: ImVec2, radius: float, col: int, num_segments: int)
+draw_list.add_text(pos: ImVec2, col: int, text: str)
+draw_list.add_polyline(points: list[ImVec2], col: int, flags: int, thickness: float)
+draw_list.add_convex_poly_filled(points: list[ImVec2], col: int)
+draw_list.add_bezier_cubic(p1: ImVec2, p2: ImVec2, p3: ImVec2, p4: ImVec2, col: int, thickness: float, num_segments: int = 0)
+draw_list.add_bezier_quadratic(p1: ImVec2, p2: ImVec2, p3: ImVec2, col: int, thickness: float, num_segments: int = 0)
+
+# Image drawing
+draw_list.add_image(user_texture_id, p_min: ImVec2, p_max: ImVec2, uv_min: ImVec2 = (0,0), uv_max: ImVec2 = (1,1), col: int = 0xFFFFFFFF)
+draw_list.add_image_quad(user_texture_id, p1: ImVec2, p2: ImVec2, p3: ImVec2, p4: ImVec2, uv1: ImVec2 = (0,0), uv2: ImVec2 = (1,0), uv3: ImVec2 = (1,1), uv4: ImVec2 = (0,1), col: int = 0xFFFFFFFF)
+draw_list.add_image_rounded(user_texture_id, p_min: ImVec2, p_max: ImVec2, uv_min: ImVec2, uv_max: ImVec2, col: int, rounding: float, flags: int = 0)
+
+# Clipping
+draw_list.push_clip_rect(clip_rect_min: ImVec2, clip_rect_max: ImVec2, intersect_with_current_clip_rect: bool = False)
+draw_list.push_clip_rect_full_screen()
+draw_list.pop_clip_rect()
+
+# Paths (for advanced shapes)
+draw_list.path_clear()
+draw_list.path_line_to(pos: ImVec2)
+draw_list.path_line_to_merge_duplicate(pos: ImVec2)
+draw_list.path_fill_convex(col: int)
+draw_list.path_stroke(col: int, flags: int, thickness: float = 1.0)
+draw_list.path_arc_to(center: ImVec2, radius: float, a_min: float, a_max: float, num_segments: int = 0)
+draw_list.path_arc_to_fast(center: ImVec2, radius: float, a_min_of_12: int, a_max_of_12: int)
+draw_list.path_bezier_cubic_curve_to(p2: ImVec2, p3: ImVec2, p4: ImVec2, num_segments: int = 0)
+draw_list.path_bezier_quadratic_curve_to(p2: ImVec2, p3: ImVec2, num_segments: int = 0)
+draw_list.path_rect(rect_min: ImVec2, rect_max: ImVec2, rounding: float = 0.0, flags: int = 0)
+```
+
+---
+
+## 18. Style & Colors
+
+```python
+# Style access
+style = imgui.get_style()
+
+# Push/Pop colors
+imgui.push_style_color(idx: int, col: int)
+imgui.push_style_color_im_vec4(idx: int, col: ImVec4)
+imgui.pop_style_color(count: int = 1)
+
+# Push/Pop style vars
+imgui.push_style_var_float(idx: int, val: float)
+imgui.push_style_var_im_vec2(idx: int, val: ImVec2)
+imgui.pop_style_var(count: int = 1)
+
+# Font
+imgui.push_font(font)
+imgui.pop_font()
+imgui.get_font()
+imgui.get_font_size() -> float
+```
+
+---
+
+## 19. Input & Focus
+
+```python
+# Keyboard
+imgui.is_key_down(key: int) -> bool
+imgui.is_key_pressed(key: int, repeat: bool = True) -> bool
+imgui.is_key_released(key: int) -> bool
+imgui.get_key_pressed_amount(key: int, repeat_delay: float, rate: float) -> int
+
+# Mouse
+imgui.is_mouse_down(button: int) -> bool
+imgui.is_mouse_clicked(button: int, repeat: bool = False) -> bool
+imgui.is_mouse_released(button: int) -> bool
+imgui.is_mouse_double_clicked(button: int) -> bool
+imgui.is_mouse_hovering_rect(r_min: ImVec2, r_max: ImVec2, clip: bool = True) -> bool
+imgui.is_mouse_dragging(button: int, lock_threshold: float = -1.0) -> bool
+imgui.get_mouse_pos() -> ImVec2
+imgui.get_mouse_pos_on_opening_current_popup() -> ImVec2
+imgui.get_mouse_drag_delta(button: int = 0, lock_threshold: float = -1.0) -> ImVec2
+
+# Focus
+imgui.set_keyboard_focus_here(offset: int = 0)
+imgui.is_item_focused() -> bool
+
+# Item state
+imgui.is_item_hovered(flags: int = 0) -> bool
+imgui.is_item_active() -> bool
+imgui.is_item_clicked(button: int = 0) -> bool
+imgui.is_item_visible() -> bool
+imgui.is_item_edited() -> bool
+imgui.is_item_activated() -> bool
+imgui.is_item_deactivated() -> bool
+imgui.is_item_deactivated_after_edit() -> bool
+imgui.is_item_toggled_open() -> bool
+```
+
+---
+
+## 20. ID Stack
+
+```python
+imgui.push_id_str(str_id: str)
+imgui.push_id_int(int_id: int)
+imgui.push_id_ptr(ptr_id)
+imgui.pop_id()
+imgui.get_id(str_id: str) -> int
+```
+
+---
+
+## Total Core ImGui Elements: 200+
+
+This reference covers all standard ImGui widgets and APIs available in imgui-bundle for Python, providing the foundation for the MCP tool implementations.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,312 @@
+# Documentation Index
+
+Complete documentation for Champi-Gen-UI MCP Server.
+
+---
+
+## 📖 Getting Started
+
+1. **[README.md](../README.md)** - Project overview and quick start guide
+2. **[PLAN_SUMMARY.md](../PLAN_SUMMARY.md)** - Executive summary of the complete plan
+3. **[IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md)** - Detailed implementation roadmap
+
+---
+
+## 🏗️ Architecture & Design
+
+4. **[ARCHITECTURE.md](ARCHITECTURE.md)** - Complete system architecture
+   - Component architecture
+   - Data flow diagrams
+   - State management
+   - Threading model
+   - Extension system
+   - Serialization format
+
+---
+
+## 📋 API References
+
+5. **[MCP_TOOLS_API.md](MCP_TOOLS_API.md)** - All 200+ MCP tools documented
+   - Canvas management tools
+   - Widget tools (all categories)
+   - Animation tools
+   - Extension tools
+   - Input/output tools
+   - Complete parameter schemas
+
+6. **[IMGUI_CORE_REFERENCE.md](IMGUI_CORE_REFERENCE.md)** - ImGui API reference
+   - All ImGui core functions
+   - Widget APIs
+   - Drawing APIs
+   - Input handling
+   - Style & theming APIs
+   - 200+ function signatures
+
+---
+
+## 🎨 Widget & Extension Guides
+
+7. **[WIDGET_CATALOG.md](WIDGET_CATALOG.md)** - Complete widget listing
+   - 150+ widgets categorized
+   - Basic widgets (buttons, text, inputs)
+   - Data widgets (tables, trees, lists)
+   - Visualization widgets (plots, charts)
+   - Custom widgets (knobs, toggles, spinners)
+   - Container widgets (windows, panels)
+
+8. **[EXTENSIONS_GUIDE.md](EXTENSIONS_GUIDE.md)** - Third-party extension integration
+   - imgui_club (memory editor, multi-context)
+   - HImGuiAnimation (keyframe animations)
+   - File dialogs (ImGuiFD, imfile)
+   - Notifications (imgui-notify)
+   - Node editors
+   - Text/code editors
+   - Plotting library (ImPlot)
+   - Custom widgets collection
+
+---
+
+## 🔧 Workflow Guides
+
+9. **[TEMPLATE_WORKFLOW.md](TEMPLATE_WORKFLOW.md)** - Template management workflow
+   - When to save templates (only when UI is complete)
+   - Template creation best practices
+   - Loading and reusing templates
+   - Template organization strategies
+   - Error handling and troubleshooting
+
+---
+
+## 📊 Quick Reference
+
+### By Topic
+
+#### Canvas & Rendering
+- Canvas modes → [IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md#21-canvas-system-mode-based)
+- Canvas tools → [MCP_TOOLS_API.md](MCP_TOOLS_API.md#1-canvas-management-7-tools)
+- Rendering architecture → [ARCHITECTURE.md](ARCHITECTURE.md#6-canvas-system-architecture)
+
+#### Widgets
+- Widget catalog → [WIDGET_CATALOG.md](WIDGET_CATALOG.md)
+- Widget architecture → [ARCHITECTURE.md](ARCHITECTURE.md#5-widget-system-architecture)
+- Widget tools → [MCP_TOOLS_API.md](MCP_TOOLS_API.md#2-basic-widgets-25-tools)
+
+#### Extensions
+- Extension guide → [EXTENSIONS_GUIDE.md](EXTENSIONS_GUIDE.md)
+- Extension architecture → [ARCHITECTURE.md](ARCHITECTURE.md#7-extension-integration)
+- Extension tools → [MCP_TOOLS_API.md](MCP_TOOLS_API.md) (various sections)
+
+#### Animation
+- Animation system → [EXTENSIONS_GUIDE.md](EXTENSIONS_GUIDE.md#2-animation-system-himguianimation)
+- Animation tools → [MCP_TOOLS_API.md](MCP_TOOLS_API.md#6-animation-tools-10-tools)
+- Animation architecture → [ARCHITECTURE.md](ARCHITECTURE.md#8-animation-system)
+
+#### Data & State
+- State management → [ARCHITECTURE.md](ARCHITECTURE.md#3-state-management)
+- Data binding → [ARCHITECTURE.md](ARCHITECTURE.md#9-data-binding-system)
+- Serialization → [ARCHITECTURE.md](ARCHITECTURE.md#10-serialization-format)
+
+---
+
+## 🎯 By Use Case
+
+### I want to...
+
+#### Create UI
+1. Read [README.md](../README.md#-usage-examples) for examples
+2. Check [MCP_TOOLS_API.md](MCP_TOOLS_API.md) for available tools
+3. Browse [WIDGET_CATALOG.md](WIDGET_CATALOG.md) for widgets
+
+#### Add Animations
+1. Read [EXTENSIONS_GUIDE.md](EXTENSIONS_GUIDE.md#2-animation-system-himguianimation)
+2. Check [MCP_TOOLS_API.md](MCP_TOOLS_API.md#6-animation-tools-10-tools)
+
+#### Plot Data
+1. Read [EXTENSIONS_GUIDE.md](EXTENSIONS_GUIDE.md#63-plotting-extensions)
+2. Check [MCP_TOOLS_API.md](MCP_TOOLS_API.md#10-plotting-tools-15-tools)
+3. Browse [WIDGET_CATALOG.md](WIDGET_CATALOG.md#plotting-widgets-implot)
+
+#### Create Node Graphs
+1. Read [EXTENSIONS_GUIDE.md](EXTENSIONS_GUIDE.md#61-node-editors)
+2. Check [MCP_TOOLS_API.md](MCP_TOOLS_API.md#11-node-editor-tools-10-tools)
+
+#### Style & Theme
+1. Read [IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md#34-styling--theming-tools)
+2. Check [MCP_TOOLS_API.md](MCP_TOOLS_API.md#5-styling--theming-12-tools)
+3. Review [IMGUI_CORE_REFERENCE.md](IMGUI_CORE_REFERENCE.md#18-style--colors)
+
+#### Save/Load UI
+1. Read [ARCHITECTURE.md](ARCHITECTURE.md#10-serialization-format)
+2. Check [MCP_TOOLS_API.md](MCP_TOOLS_API.md#17-exportimport-tools-8-tools)
+3. Follow [TEMPLATE_WORKFLOW.md](TEMPLATE_WORKFLOW.md) for template management
+
+#### Extend System
+1. Read [ARCHITECTURE.md](ARCHITECTURE.md#7-extension-integration)
+2. Review [EXTENSIONS_GUIDE.md](EXTENSIONS_GUIDE.md#8-integration-summary)
+
+---
+
+## 📚 Reference Tables
+
+### Widget Count by Category
+| Category | Count | Reference |
+|----------|-------|-----------|
+| Basic Widgets | 25+ | [WIDGET_CATALOG.md](WIDGET_CATALOG.md#basic-input-widgets) |
+| Selection Widgets | 10+ | [WIDGET_CATALOG.md](WIDGET_CATALOG.md#selection-widgets) |
+| Slider/Drag Widgets | 15+ | [WIDGET_CATALOG.md](WIDGET_CATALOG.md#slider--drag-widgets) |
+| Color Widgets | 5+ | [WIDGET_CATALOG.md](WIDGET_CATALOG.md#color-widgets) |
+| Container Widgets | 5+ | [WIDGET_CATALOG.md](WIDGET_CATALOG.md#container-widgets) |
+| Table Widgets | 10+ | [WIDGET_CATALOG.md](WIDGET_CATALOG.md#table-widgets) |
+| Plotting Widgets | 15+ | [WIDGET_CATALOG.md](WIDGET_CATALOG.md#plotting-widgets-implot) |
+| Node Editor | 10+ | [WIDGET_CATALOG.md](WIDGET_CATALOG.md#node-editor-widgets) |
+| Custom Widgets | 10+ | [WIDGET_CATALOG.md](WIDGET_CATALOG.md#custom-extended-widgets) |
+| **Total** | **150+** | [WIDGET_CATALOG.md](WIDGET_CATALOG.md) |
+
+### MCP Tool Count by Category
+| Category | Count | Reference |
+|----------|-------|-----------|
+| Canvas Management | 7 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#1-canvas-management-7-tools) |
+| Basic Widgets | 25 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#2-basic-widgets-25-tools) |
+| Container Widgets | 5 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#3-container-widgets-5-tools) |
+| Layout Tools | 10 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#4-layout-tools-10-tools) |
+| Styling & Theming | 12 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#5-styling--theming-12-tools) |
+| Animation Tools | 10 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#6-animation-tools-10-tools) |
+| File Dialogs | 5 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#7-file-dialog-tools-5-tools) |
+| Notifications | 7 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#8-notification-tools-7-tools) |
+| Tables | 10 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#9-table-tools-10-tools) |
+| Plotting | 15 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#10-plotting-tools-15-tools) |
+| Node Editor | 10 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#11-node-editor-tools-10-tools) |
+| Text Editor | 8 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#12-text-editor-tools-8-tools) |
+| Memory Editor | 5 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#13-memory-editor-tools-5-tools) |
+| Input Handling | 10 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#14-input-handling-tools-10-tools) |
+| Drawing Tools | 15 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#15-drawing-tools-15-tools) |
+| Data Binding | 8 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#16-data-binding-tools-8-tools) |
+| Export/Import | 8 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#17-exportimport-tools-8-tools) |
+| Custom Widgets | 10 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#18-custom-widgets-10-tools) |
+| Advanced Features | 8 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#19-advanced-features-8-tools) |
+| Utility Tools | 7 | [MCP_TOOLS_API.md](MCP_TOOLS_API.md#20-utility-tools-7-tools) |
+| **Total** | **200+** | [MCP_TOOLS_API.md](MCP_TOOLS_API.md) |
+
+### Extension Library Count
+| Extension | Type | Reference |
+|-----------|------|-----------|
+| imgui_club | Multi-tools | [EXTENSIONS_GUIDE.md](EXTENSIONS_GUIDE.md#1-imgui-club-extensions) |
+| HImGuiAnimation | Animation | [EXTENSIONS_GUIDE.md](EXTENSIONS_GUIDE.md#2-animation-system-himguianimation) |
+| ImGuiFD | File Dialog | [EXTENSIONS_GUIDE.md](EXTENSIONS_GUIDE.md#31-imgui fd) |
+| imfile | File Browser | [EXTENSIONS_GUIDE.md](EXTENSIONS_GUIDE.md#32-imfile-rust-based-alternative) |
+| imgui-notify | Notifications | [EXTENSIONS_GUIDE.md](EXTENSIONS_GUIDE.md#4-notifications-imgui-notify) |
+| Useful Widgets | Custom Widgets | [EXTENSIONS_GUIDE.md](EXTENSIONS_GUIDE.md#5-useful-widgets-collection) |
+| ImNodes | Node Editor | [EXTENSIONS_GUIDE.md](EXTENSIONS_GUIDE.md#61-node-editors) |
+| ImGuiColorTextEdit | Text Editor | [EXTENSIONS_GUIDE.md](EXTENSIONS_GUIDE.md#62-text-editors) |
+| ImPlot | Plotting | [EXTENSIONS_GUIDE.md](EXTENSIONS_GUIDE.md#63-plotting-extensions) |
+| Custom Collection | Knobs/Toggles/etc | [EXTENSIONS_GUIDE.md](EXTENSIONS_GUIDE.md#7-custom-widget-extensions) |
+| **Total** | **10+** | [EXTENSIONS_GUIDE.md](EXTENSIONS_GUIDE.md) |
+
+---
+
+## 🔍 Search Tips
+
+### Finding Specific Information
+
+**Looking for a widget?**
+→ [WIDGET_CATALOG.md](WIDGET_CATALOG.md) (Ctrl+F widget name)
+
+**Looking for an MCP tool?**
+→ [MCP_TOOLS_API.md](MCP_TOOLS_API.md) (Ctrl+F tool name)
+
+**Looking for ImGui function?**
+→ [IMGUI_CORE_REFERENCE.md](IMGUI_CORE_REFERENCE.md) (Ctrl+F function name)
+
+**Looking for an extension?**
+→ [EXTENSIONS_GUIDE.md](EXTENSIONS_GUIDE.md) (Ctrl+F extension name)
+
+**Looking for architecture details?**
+→ [ARCHITECTURE.md](ARCHITECTURE.md) (Ctrl+F component name)
+
+**Looking for implementation details?**
+→ [IMPLEMENTATION_PLAN.md](../IMPLEMENTATION_PLAN.md) (Ctrl+F feature name)
+
+---
+
+## 📝 Documentation Conventions
+
+### File Naming
+- **UPPERCASE.md** - Top-level project docs (root directory)
+- **Title_Case.md** - Reference documentation (docs directory)
+- All docs use `.md` (Markdown) format
+
+### Content Structure
+- **H1 (#)** - Document title
+- **H2 (##)** - Major sections
+- **H3 (###)** - Subsections
+- **H4 (####)** - Details
+
+### Code Examples
+- Python code blocks use \`\`\`python
+- JSON examples use \`\`\`json
+- Inline code uses \`backticks\`
+
+### Links
+- Internal links use relative paths
+- External links use full URLs
+- Anchors use lowercase with hyphens
+
+---
+
+## 🗂️ File Tree
+
+```
+champi-gen-ui/
+├── README.md                      # Project overview
+├── IMPLEMENTATION_PLAN.md         # Implementation roadmap
+├── PLAN_SUMMARY.md                # Executive summary
+├── RENDERING_INFRASTRUCTURE.md    # Rendering system docs
+├── docs/
+│   ├── INDEX.md                   # This file
+│   ├── ARCHITECTURE.md            # System architecture
+│   ├── MCP_TOOLS_API.md           # MCP tools reference
+│   ├── WIDGET_CATALOG.md          # Widget listing
+│   ├── EXTENSIONS_GUIDE.md        # Extensions guide
+│   ├── TEMPLATE_WORKFLOW.md       # Template workflow guide
+│   └── IMGUI_CORE_REFERENCE.md    # ImGui API reference
+├── fast-mcp-docs/
+│   ├── full-documentation.txt     # FastMCP docs
+│   └── sitemap.txt                # FastMCP sitemap
+└── imgui-docs/
+    ├── flgt.pdf                   # FLGT manual
+    ├── hello_imgui_manual.pdf     # Hello ImGui manual
+    └── imgui_bundle_manual.pdf    # ImGui Bundle manual
+```
+
+---
+
+## 📈 Documentation Stats
+
+- **Total Documents**: 9 markdown files
+- **Total Pages**: ~110+ pages
+- **Total Words**: ~55,000+ words
+- **Widgets Documented**: 150+
+- **MCP Tools Documented**: 200+
+- **ImGui Functions**: 200+
+- **Extensions Covered**: 10+
+
+---
+
+## 🔄 Documentation Updates
+
+This documentation is comprehensive but may be updated as the project evolves. Check the git history for changes:
+
+```bash
+git log -- docs/
+```
+
+---
+
+## 📧 Feedback
+
+Found an error or have a suggestion? Please open an issue or submit a pull request!
+
+---
+
+**Last Updated**: 2025-10-03
+**Version**: 1.0 (Planning Phase)

--- a/docs/MCP_TOOLS_API.md
+++ b/docs/MCP_TOOLS_API.md
@@ -1,0 +1,887 @@
+# MCP Tools API Reference
+
+Complete listing of all MCP tools for the Champi-Gen-UI server.
+
+---
+
+## 1. Canvas Management (7 tools)
+
+### create_canvas
+Create a new ImGui canvas for rendering UI.
+
+```python
+{
+    "name": "create_canvas",
+    "description": "Create a new canvas for rendering ImGui UI",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "canvas_id": {"type": "string", "description": "Unique canvas identifier"},
+            "width": {"type": "integer", "default": 1280},
+            "height": {"type": "integer", "default": 720},
+            "mode": {"type": "string", "enum": ["standard", "docking", "multi_viewport", "fullscreen", "overlay"], "default": "standard"},
+            "title": {"type": "string", "default": "ImGui Canvas"}
+        },
+        "required": ["canvas_id"]
+    }
+}
+```
+
+### update_canvas
+Modify canvas properties.
+
+### clear_canvas
+Reset canvas to empty state.
+
+### get_canvas_state
+Retrieve current canvas state and all widgets.
+
+### set_canvas_mode
+Switch between canvas rendering modes.
+
+### resize_canvas
+Adjust canvas dimensions.
+
+### capture_canvas
+Take screenshot or export canvas.
+
+---
+
+## 2. Basic Widgets (25 tools)
+
+### add_button
+```python
+{
+    "name": "add_button",
+    "description": "Add a clickable button to the canvas",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "canvas_id": {"type": "string"},
+            "widget_id": {"type": "string"},
+            "label": {"type": "string"},
+            "position": {"type": "array", "items": {"type": "number"}, "minItems": 2, "maxItems": 2},
+            "size": {"type": "array", "items": {"type": "number"}, "minItems": 2, "maxItems": 2},
+            "callback": {"type": "string", "description": "Callback function name"}
+        },
+        "required": ["canvas_id", "widget_id", "label"]
+    }
+}
+```
+
+### add_text
+Add static text label.
+
+### add_input_text
+Add text input field.
+
+### add_checkbox
+Add checkbox widget.
+
+### add_radio_button
+Add radio button.
+
+### add_slider_int
+Add integer slider.
+
+### add_slider_float
+Add float slider.
+
+### add_drag_int
+Add integer drag control.
+
+### add_drag_float
+Add float drag control.
+
+### add_combo
+Add dropdown combo box.
+
+### add_list_box
+Add scrollable list.
+
+### add_color_picker
+Add color picker widget.
+
+### add_tree_node
+Add collapsible tree node.
+
+### add_tab_bar
+Add tab container.
+
+### add_menu
+Add menu item.
+
+### add_tooltip
+Add hover tooltip.
+
+### add_progress_bar
+Add progress indicator.
+
+### add_separator
+Add horizontal separator.
+
+### add_spacing
+Add vertical spacing.
+
+### add_image
+Display image texture.
+
+### add_small_button
+Add compact button.
+
+### add_arrow_button
+Add directional arrow button.
+
+### add_input_int
+Add integer input field.
+
+### add_input_float
+Add float input field.
+
+### add_selectable
+Add selectable item.
+
+---
+
+## 3. Container Widgets (5 tools)
+
+### add_window
+```python
+{
+    "name": "add_window",
+    "description": "Add a standalone window container",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "canvas_id": {"type": "string"},
+            "window_id": {"type": "string"},
+            "title": {"type": "string"},
+            "position": {"type": "array", "items": {"type": "number"}},
+            "size": {"type": "array", "items": {"type": "number"}},
+            "flags": {"type": "array", "items": {"type": "string"}}
+        },
+        "required": ["canvas_id", "window_id", "title"]
+    }
+}
+```
+
+### add_child_window
+Add embedded child region.
+
+### add_group
+Add layout group.
+
+### add_panel
+Add custom panel.
+
+### add_collapsing_header
+Add collapsible section header.
+
+---
+
+## 4. Layout Tools (10 tools)
+
+### set_layout_horizontal
+Arrange widgets horizontally.
+
+### set_layout_vertical
+Arrange widgets vertically.
+
+### set_layout_grid
+Create grid layout.
+
+### set_layout_stack
+Stack widgets.
+
+### add_indent
+Add indentation.
+
+### set_item_width
+Set widget width.
+
+### align_text
+Align text content.
+
+### center_widget
+Center widget in container.
+
+### set_cursor_position
+Manually position cursor.
+
+### get_content_region_avail
+Get available space.
+
+---
+
+## 5. Styling & Theming (12 tools)
+
+### set_color_scheme
+```python
+{
+    "name": "set_color_scheme",
+    "description": "Apply a color theme to the canvas",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "canvas_id": {"type": "string"},
+            "theme": {"type": "string", "enum": ["dark", "light", "classic", "dracula", "nord", "gruvbox"]}
+        },
+        "required": ["canvas_id", "theme"]
+    }
+}
+```
+
+### set_widget_style
+Style individual widget.
+
+### set_font
+Change font family.
+
+### set_font_size
+Adjust font size.
+
+### set_spacing
+Configure padding/margins.
+
+### apply_rounded_corners
+Enable rounded corners.
+
+### set_transparency
+Set widget transparency.
+
+### set_border_color
+Configure border color.
+
+### set_background_color
+Set background color.
+
+### push_style_var
+Push style variable.
+
+### pop_style_var
+Pop style variable.
+
+### get_style
+Get current style settings.
+
+---
+
+## 6. Animation Tools (10 tools)
+
+### create_animation
+```python
+{
+    "name": "create_animation",
+    "description": "Create keyframe-based animation",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "animation_id": {"type": "string"},
+            "keyframes": {"type": "array", "items": {"type": "integer"}},
+            "values": {"type": "array", "items": {"type": "number"}},
+            "duration": {"type": "number"},
+            "easing": {"type": "string", "enum": ["linear", "ease_in", "ease_out", "ease_in_out", "cubic", "bounce", "elastic"]}
+        },
+        "required": ["animation_id", "keyframes", "values"]
+    }
+}
+```
+
+### animate_value
+Interpolate animated value.
+
+### play_animation
+Start animation playback.
+
+### pause_animation
+Pause animation.
+
+### stop_animation
+Stop animation.
+
+### set_easing_function
+Configure interpolation.
+
+### create_transition
+Create state transition.
+
+### set_animation_loop
+Enable/disable looping.
+
+### get_animation_state
+Query animation status.
+
+### delete_animation
+Remove animation.
+
+---
+
+## 7. File Dialog Tools (5 tools)
+
+### open_file_dialog
+```python
+{
+    "name": "open_file_dialog",
+    "description": "Open file selection dialog",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string", "default": "Open File"},
+            "initial_path": {"type": "string"},
+            "filters": {"type": "array", "items": {"type": "string"}},
+            "allow_multiple": {"type": "boolean", "default": false}
+        }
+    }
+}
+```
+
+### open_dir_dialog
+Open directory picker.
+
+### save_file_dialog
+Open save file dialog.
+
+### set_file_filters
+Configure file type filters.
+
+### get_selected_files
+Retrieve selected files.
+
+---
+
+## 8. Notification Tools (7 tools)
+
+### show_notification
+```python
+{
+    "name": "show_notification",
+    "description": "Show toast notification",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "type": {"type": "string", "enum": ["success", "warning", "error", "info"]},
+            "message": {"type": "string"},
+            "title": {"type": "string"},
+            "duration": {"type": "integer", "default": 3000}
+        },
+        "required": ["type", "message"]
+    }
+}
+```
+
+### show_success
+Show success notification.
+
+### show_warning
+Show warning notification.
+
+### show_error
+Show error notification.
+
+### show_info
+Show info notification.
+
+### clear_notifications
+Clear all notifications.
+
+### set_notification_position
+Set notification position.
+
+---
+
+## 9. Table Tools (10 tools)
+
+### create_table
+```python
+{
+    "name": "create_table",
+    "description": "Create data table widget",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "canvas_id": {"type": "string"},
+            "table_id": {"type": "string"},
+            "columns": {"type": "integer"},
+            "rows": {"type": "array", "items": {"type": "array"}},
+            "headers": {"type": "array", "items": {"type": "string"}},
+            "flags": {"type": "array", "items": {"type": "string"}}
+        },
+        "required": ["canvas_id", "table_id", "columns"]
+    }
+}
+```
+
+### table_add_row
+Add row to table.
+
+### table_set_cell
+Set cell value.
+
+### table_get_cell
+Get cell value.
+
+### table_setup_column
+Configure column.
+
+### table_sort
+Sort table data.
+
+### table_filter
+Filter table rows.
+
+### table_set_column_width
+Set column width.
+
+### table_enable_sorting
+Enable sortable columns.
+
+### table_enable_resizing
+Enable column resizing.
+
+---
+
+## 10. Plotting Tools (15 tools)
+
+### add_line_plot
+```python
+{
+    "name": "add_line_plot",
+    "description": "Create line chart",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "canvas_id": {"type": "string"},
+            "plot_id": {"type": "string"},
+            "x_data": {"type": "array", "items": {"type": "number"}},
+            "y_data": {"type": "array", "items": {"type": "number"}},
+            "label": {"type": "string"},
+            "color": {"type": "array", "items": {"type": "number"}}
+        },
+        "required": ["canvas_id", "plot_id", "x_data", "y_data"]
+    }
+}
+```
+
+### add_scatter_plot
+Create scatter plot.
+
+### add_bar_chart
+Create bar chart.
+
+### add_histogram
+Create histogram.
+
+### add_heatmap
+Create heat map.
+
+### add_pie_chart
+Create pie chart.
+
+### add_area_plot
+Create filled area plot.
+
+### add_stem_plot
+Create stem plot.
+
+### add_error_bars
+Add error bars.
+
+### add_candlestick
+Create candlestick chart.
+
+### plot_set_limits
+Set axis limits.
+
+### plot_set_labels
+Set axis labels.
+
+### plot_set_legend
+Configure legend.
+
+### plot_add_annotation
+Add text annotation.
+
+### plot_enable_crosshair
+Enable crosshair cursor.
+
+---
+
+## 11. Node Editor Tools (10 tools)
+
+### create_node_editor
+```python
+{
+    "name": "create_node_editor",
+    "description": "Create node graph editor",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "canvas_id": {"type": "string"},
+            "editor_id": {"type": "string"},
+            "style": {"type": "string", "default": "default"}
+        },
+        "required": ["canvas_id", "editor_id"]
+    }
+}
+```
+
+### add_node
+Add node to graph.
+
+### add_node_input
+Add input pin to node.
+
+### add_node_output
+Add output pin to node.
+
+### add_link
+Connect nodes.
+
+### remove_node
+Delete node.
+
+### remove_link
+Delete connection.
+
+### get_node_connections
+Query node connections.
+
+### set_node_position
+Position node.
+
+### get_selected_nodes
+Get selected nodes.
+
+---
+
+## 12. Text Editor Tools (8 tools)
+
+### create_code_editor
+```python
+{
+    "name": "create_code_editor",
+    "description": "Create syntax-highlighted code editor",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "canvas_id": {"type": "string"},
+            "editor_id": {"type": "string"},
+            "language": {"type": "string", "default": "python"},
+            "read_only": {"type": "boolean", "default": false}
+        },
+        "required": ["canvas_id", "editor_id"]
+    }
+}
+```
+
+### set_editor_text
+Set editor content.
+
+### get_editor_text
+Get editor content.
+
+### set_editor_language
+Change syntax highlighting.
+
+### set_editor_readonly
+Toggle read-only mode.
+
+### editor_add_breakpoint
+Add breakpoint marker.
+
+### editor_goto_line
+Jump to line number.
+
+### editor_find_replace
+Find and replace text.
+
+---
+
+## 13. Memory Editor Tools (5 tools)
+
+### add_memory_editor
+Create hex editor widget.
+
+### set_memory_data
+Load data into editor.
+
+### set_memory_readonly
+Toggle read-only mode.
+
+### highlight_memory_range
+Highlight byte range.
+
+### get_memory_selection
+Get selected bytes.
+
+---
+
+## 14. Input Handling Tools (10 tools)
+
+### register_key_callback
+Register keyboard event handler.
+
+### register_mouse_callback
+Register mouse event handler.
+
+### register_click_callback
+Register click handler.
+
+### set_drag_drop_source
+Enable drag source.
+
+### set_drag_drop_target
+Enable drop target.
+
+### capture_input_state
+Poll input state.
+
+### is_key_pressed
+Check key state.
+
+### is_mouse_clicked
+Check mouse button.
+
+### get_mouse_position
+Get cursor position.
+
+### set_keyboard_focus
+Set input focus.
+
+---
+
+## 15. Drawing Tools (15 tools)
+
+### draw_line
+Draw line on canvas.
+
+### draw_rect
+Draw rectangle.
+
+### draw_circle
+Draw circle.
+
+### draw_polygon
+Draw polygon.
+
+### draw_text
+Draw text.
+
+### draw_image
+Draw image texture.
+
+### draw_bezier_curve
+Draw bezier curve.
+
+### draw_arrow
+Draw arrow.
+
+### set_clip_rect
+Set clipping region.
+
+### push_draw_layer
+Create draw layer.
+
+### pop_draw_layer
+Remove draw layer.
+
+### get_draw_list
+Get canvas draw list.
+
+### draw_grid
+Draw grid lines.
+
+### draw_crosshair
+Draw crosshair.
+
+### clear_drawings
+Clear all drawings.
+
+---
+
+## 16. Data Binding Tools (8 tools)
+
+### bind_data_source
+Connect external data source.
+
+### create_live_chart
+Create real-time chart.
+
+### update_widget_data
+Update widget dynamically.
+
+### watch_variable
+Watch variable changes.
+
+### bind_widget_property
+Bind widget to data.
+
+### unbind_widget
+Remove data binding.
+
+### refresh_data
+Refresh bound data.
+
+### get_bound_data
+Query bound data.
+
+---
+
+## 17. Export/Import Tools (8 tools)
+
+### export_ui_json
+```python
+{
+    "name": "export_ui_json",
+    "description": "Export UI definition as JSON",
+    "inputSchema": {
+        "type": "object",
+        "properties": {
+            "canvas_id": {"type": "string"},
+            "file_path": {"type": "string"}
+        },
+        "required": ["canvas_id"]
+    }
+}
+```
+
+### import_ui_json
+Load UI from JSON.
+
+### generate_code
+Export to Python code.
+
+### create_template
+Save as template.
+
+### load_template
+Load UI template.
+
+### list_templates
+List available templates.
+
+### delete_template
+Remove template.
+
+### export_screenshot
+Save canvas image.
+
+---
+
+## 18. Custom Widgets (10 tools)
+
+### add_knob
+Add rotary knob.
+
+### add_toggle
+Add toggle switch.
+
+### add_spinner
+Add loading spinner.
+
+### add_date_picker
+Add date selector.
+
+### add_time_picker
+Add time selector.
+
+### add_gradient_editor
+Add gradient editor.
+
+### add_color_gradient
+Display color gradient.
+
+### add_spin_input
+Add spin input.
+
+### add_slider_2d
+Add 2D slider.
+
+### add_slider_3d
+Add 3D slider.
+
+---
+
+## 19. Advanced Features (8 tools)
+
+### enable_docking
+Enable window docking.
+
+### enable_multi_viewport
+Enable multi-viewport.
+
+### create_viewport
+Create new viewport.
+
+### set_viewport_properties
+Configure viewport.
+
+### enable_keyboard_nav
+Enable keyboard navigation.
+
+### enable_gamepad_nav
+Enable gamepad navigation.
+
+### set_ini_filename
+Set layout save file.
+
+### load_layout
+Load saved layout.
+
+---
+
+## 20. Utility Tools (7 tools)
+
+### get_widget_bounds
+Get widget dimensions.
+
+### is_widget_hovered
+Check hover state.
+
+### is_widget_focused
+Check focus state.
+
+### set_widget_visible
+Show/hide widget.
+
+### delete_widget
+Remove widget.
+
+### get_all_widgets
+List all widgets.
+
+### get_widget_property
+Get widget property.
+
+---
+
+## Summary
+
+**Total MCP Tools: 200+**
+
+Organized into 20 categories:
+1. Canvas Management (7)
+2. Basic Widgets (25)
+3. Container Widgets (5)
+4. Layout Tools (10)
+5. Styling & Theming (12)
+6. Animation Tools (10)
+7. File Dialog Tools (5)
+8. Notification Tools (7)
+9. Table Tools (10)
+10. Plotting Tools (15)
+11. Node Editor Tools (10)
+12. Text Editor Tools (8)
+13. Memory Editor Tools (5)
+14. Input Handling Tools (10)
+15. Drawing Tools (15)
+16. Data Binding Tools (8)
+17. Export/Import Tools (8)
+18. Custom Widgets (10)
+19. Advanced Features (8)
+20. Utility Tools (7)
+
+All tools return structured responses with:
+- `success`: Boolean indicating operation success
+- `data`: Result data or widget state
+- `error`: Error message if applicable

--- a/docs/TEMPLATE_WORKFLOW.md
+++ b/docs/TEMPLATE_WORKFLOW.md
@@ -1,0 +1,373 @@
+# Template Workflow Guide
+
+## Overview
+
+This guide explains how to save and reuse UI templates in champi-gen-ui. Templates allow you to save complete UI designs and load them later for reuse or modification.
+
+## When to Save Templates
+
+**Templates should only be saved when the author is done creating their UI.**
+
+Save a template when:
+- ✅ All widgets have been added and positioned
+- ✅ Layout is finalized
+- ✅ Styling and theming is complete
+- ✅ The UI is tested and working
+- ✅ You want to reuse this design later
+
+**Do NOT save templates:**
+- ❌ During active development/iteration
+- ❌ When still experimenting with layouts
+- ❌ Before testing the UI
+- ❌ For temporary/throwaway designs
+
+## Workflow
+
+### 1. Create Your UI
+
+Use MCP tools to build your interface:
+
+```python
+# Create canvas
+create_canvas(
+    canvas_id="my_dashboard",
+    width=1280,
+    height=720,
+    title="Analytics Dashboard"
+)
+
+# Add widgets
+add_text(
+    canvas_id="my_dashboard",
+    widget_id="title",
+    text="Sales Analytics",
+    position=[10, 10]
+)
+
+add_button(
+    canvas_id="my_dashboard",
+    widget_id="refresh_btn",
+    label="Refresh Data",
+    position=[10, 50]
+)
+
+add_line_chart(
+    canvas_id="my_dashboard",
+    widget_id="sales_chart",
+    title="Monthly Sales",
+    x_data=[1, 2, 3, 4, 5],
+    y_data=[100, 150, 120, 180, 200]
+)
+
+# ... add more widgets
+```
+
+### 2. Test Your UI
+
+Verify everything works:
+- All widgets appear correctly
+- Layout looks good
+- Interactions work as expected
+- No errors in console
+
+### 3. Save as Template
+
+**Only when you're completely done**, save the template:
+
+```python
+save_template(
+    name="analytics_dashboard",
+    canvas_id="my_dashboard",
+    description="Complete analytics dashboard with sales charts, filters, and data tables"
+)
+```
+
+**Result:**
+```json
+{
+  "success": true,
+  "data": {
+    "message": "Saved template: analytics_dashboard"
+  }
+}
+```
+
+The template is saved to: `./templates/analytics_dashboard.json`
+
+### 4. Load Template Later
+
+When you need to reuse the design:
+
+```python
+load_template(name="analytics_dashboard")
+```
+
+**Result:**
+```json
+{
+  "success": true,
+  "data": {
+    "canvas_id": "my_dashboard",
+    "widgets": [...],
+    "mode": "standard",
+    ...
+  }
+}
+```
+
+## Template Management
+
+### List All Templates
+
+```python
+list_templates()
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "templates": [
+      {
+        "name": "analytics_dashboard",
+        "description": "Complete analytics dashboard...",
+        "created": "2025-10-19T02:30:00Z",
+        "widget_count": 15
+      },
+      {
+        "name": "login_form",
+        "description": "User login form with validation",
+        "created": "2025-10-18T14:20:00Z",
+        "widget_count": 5
+      }
+    ]
+  }
+}
+```
+
+### Delete Template
+
+```python
+delete_template(name="old_template")
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "message": "Deleted template: old_template"
+  }
+}
+```
+
+## Best Practices
+
+### 1. Use Descriptive Names
+
+**Good:**
+```python
+save_template("ecommerce_product_grid", canvas_id, "Product grid with filters and pagination")
+save_template("user_settings_panel", canvas_id, "Settings panel with tabs and form inputs")
+save_template("analytics_realtime_dashboard", canvas_id, "Real-time analytics with live charts")
+```
+
+**Bad:**
+```python
+save_template("test", canvas_id, "")
+save_template("ui1", canvas_id, "some stuff")
+save_template("template", canvas_id, "template")
+```
+
+### 2. Add Meaningful Descriptions
+
+Include:
+- Purpose of the UI
+- Key features/widgets
+- Use cases
+- Any special configurations
+
+**Example:**
+```python
+save_template(
+    name="customer_support_dashboard",
+    canvas_id="support_ui",
+    description="""
+    Customer support dashboard with:
+    - Ticket list with status filters
+    - Real-time chat widget
+    - Customer info panel
+    - Response templates dropdown
+    - Analytics charts (response time, satisfaction)
+    Use for customer service teams handling support tickets.
+    """
+)
+```
+
+### 3. Organize by Category
+
+Use naming conventions:
+```python
+# Dashboards
+save_template("dashboard_analytics", ...)
+save_template("dashboard_admin", ...)
+save_template("dashboard_sales", ...)
+
+# Forms
+save_template("form_login", ...)
+save_template("form_registration", ...)
+save_template("form_checkout", ...)
+
+# Components
+save_template("component_navbar", ...)
+save_template("component_sidebar", ...)
+save_template("component_footer", ...)
+```
+
+### 4. Version Your Templates
+
+For significant changes:
+```python
+save_template("dashboard_v1", ...)
+save_template("dashboard_v2", ...)
+save_template("dashboard_v3", ...)
+```
+
+Or use dates:
+```python
+save_template("dashboard_2025_10_19", ...)
+```
+
+### 5. Document Widget Dependencies
+
+In the description, note any special requirements:
+```python
+save_template(
+    name="advanced_charting_panel",
+    canvas_id="charts",
+    description="""
+    Advanced charting panel with multiple chart types.
+
+    Dependencies:
+    - Requires ImPlot extension
+    - Uses custom color theme 'dark_charts'
+    - Expects data binding to 'analytics.data' path
+
+    Widgets: 5 line charts, 2 bar charts, 1 heatmap
+    """
+)
+```
+
+## Template File Structure
+
+Templates are saved as JSON files in `./templates/`:
+
+```json
+{
+  "template_name": "analytics_dashboard",
+  "description": "Complete analytics dashboard with sales charts",
+  "canvas_id": "my_dashboard",
+  "size": [1280, 720],
+  "mode": "standard",
+  "title": "Analytics Dashboard",
+  "theme": "dark",
+  "widgets": [
+    {
+      "widget_id": "title",
+      "type": "text",
+      "properties": {
+        "text": "Sales Analytics",
+        "color": [0.2, 0.8, 0.2, 1.0]
+      },
+      "position": [10, 10],
+      "visible": true
+    },
+    {
+      "widget_id": "sales_chart",
+      "type": "line_chart",
+      "properties": {
+        "title": "Monthly Sales",
+        "x_data": [1, 2, 3, 4, 5],
+        "y_data": [100, 150, 120, 180, 200]
+      },
+      "position": [10, 100],
+      "visible": true
+    }
+  ]
+}
+```
+
+## Advanced Usage
+
+### Programmatic Template Creation
+
+```python
+# Create base template
+create_canvas(canvas_id="base", title="Base Template")
+add_text(canvas_id="base", widget_id="header", text="Header")
+add_separator(canvas_id="base", widget_id="sep1")
+save_template("base_layout", "base", "Reusable base layout")
+
+# Load and customize
+loaded = load_template("base_layout")
+add_button(canvas_id="base", widget_id="action", label="Action")
+save_template("base_with_action", "base", "Base layout with action button")
+```
+
+### Template Composition
+
+```python
+# Save individual components
+save_template("navbar", "nav_canvas", "Navigation bar")
+save_template("sidebar", "side_canvas", "Sidebar menu")
+save_template("footer", "foot_canvas", "Footer")
+
+# Combine them
+load_template("navbar")
+load_template("sidebar")
+load_template("footer")
+# Position and arrange
+save_template("complete_layout", "main", "Full page layout")
+```
+
+## Error Handling
+
+### Template Already Exists
+
+```python
+save_template("existing", canvas_id, "description")
+# Overwrites the existing template
+```
+
+### Canvas Not Found
+
+```python
+save_template("new", "nonexistent_canvas", "")
+# Returns: {"success": false, "error": "Canvas nonexistent_canvas not found"}
+```
+
+### Invalid Template Name
+
+```python
+load_template("does_not_exist")
+# Returns: {"success": false, "error": "Template not found: does_not_exist"}
+```
+
+## Summary
+
+**Key Principles:**
+
+1. **Build first, save last** - Only save when UI is complete
+2. **Be descriptive** - Use clear names and detailed descriptions
+3. **Organize systematically** - Use naming conventions
+4. **Document dependencies** - Note special requirements
+5. **Test before saving** - Ensure everything works
+
+**Workflow:**
+1. Create UI with MCP tools
+2. Test and refine
+3. Save template when done
+4. Reuse later with load_template
+
+Templates enable you to build a library of reusable UI patterns that can be quickly deployed and customized for different applications.

--- a/docs/WIDGET_CATALOG.md
+++ b/docs/WIDGET_CATALOG.md
@@ -1,0 +1,291 @@
+# Widget Catalog - Complete Reference
+
+## Basic Input Widgets
+
+### Button
+- **add_button**: Standard clickable button
+- **add_small_button**: Compact button variant
+- **add_arrow_button**: Directional arrow button
+- **add_invisible_button**: Clickable area without visual
+
+### Text Widgets
+- **add_text**: Static text label
+- **add_text_colored**: Colored text
+- **add_text_disabled**: Grayed-out text
+- **add_text_wrapped**: Auto-wrapping text
+- **add_bullet_text**: Bulleted text
+- **add_label_text**: Label-value pair
+
+### Input Fields
+- **add_input_text**: Single-line text input
+- **add_input_text_multiline**: Multi-line text area
+- **add_input_text_with_hint**: Input with placeholder
+- **add_input_int**: Integer input
+- **add_input_float**: Float input
+- **add_input_double**: Double precision input
+- **add_input_scalar**: Generic scalar input
+
+---
+
+## Selection Widgets
+
+### Checkbox & Radio
+- **add_checkbox**: Boolean checkbox
+- **add_checkbox_flags**: Multi-flag checkbox
+- **add_radio_button**: Radio button (single)
+- **add_radio_button_group**: Radio button group
+
+### Combo & List
+- **add_combo**: Dropdown combo box
+- **add_combo_simple**: Simple string combo
+- **add_list_box**: Scrollable list
+- **add_selectable**: Selectable item
+- **add_selectable_with_bool**: Selectable with state
+
+---
+
+## Slider & Drag Widgets
+
+### Sliders
+- **add_slider_int**: Integer slider
+- **add_slider_float**: Float slider
+- **add_slider_angle**: Angle slider (degrees/radians)
+- **add_slider_int2/3/4**: Multi-component sliders
+- **add_slider_float2/3/4**: Vector sliders
+- **add_v_slider**: Vertical slider
+
+### Drag Controls
+- **add_drag_int**: Integer drag control
+- **add_drag_float**: Float drag control
+- **add_drag_int2/3/4**: Multi-component drag
+- **add_drag_float2/3/4**: Vector drag
+
+---
+
+## Color Widgets
+
+- **add_color_edit3**: RGB color picker
+- **add_color_edit4**: RGBA color picker
+- **add_color_picker3**: RGB picker dialog
+- **add_color_picker4**: RGBA picker dialog
+- **add_color_button**: Color preview button
+
+---
+
+## Tree & Hierarchy Widgets
+
+- **add_tree_node**: Collapsible tree node
+- **add_tree_node_ex**: Tree with flags
+- **add_collapsing_header**: Collapsible section
+- **add_tree_push**: Manual tree depth
+
+---
+
+## Menu & Navigation
+
+### Menus
+- **add_menu_bar**: Main menu bar
+- **add_menu**: Menu item
+- **add_menu_item**: Menu entry
+- **add_menu_item_checkable**: Checkable menu
+
+### Tabs
+- **add_tab_bar**: Tab container
+- **add_tab_item**: Tab page
+- **add_tab_item_button**: Tab with button
+
+---
+
+## Container Widgets
+
+### Windows
+- **add_window**: Standalone window
+- **add_child_window**: Embedded child region
+- **add_child_frame**: Framed child region
+
+### Groups & Panels
+- **add_group**: Layout group
+- **add_indent**: Indented block
+- **add_panel**: Custom panel
+
+---
+
+## Table Widgets
+
+- **begin_table**: Start table
+- **table_next_row**: New table row
+- **table_next_column**: Next column
+- **table_set_column_index**: Jump to column
+- **table_setup_column**: Configure column
+- **table_headers_row**: Header row
+
+---
+
+## Plotting Widgets (ImPlot)
+
+### Line Plots
+- **add_line_plot**: Line chart
+- **add_scatter_plot**: Scatter plot
+- **add_stairs_plot**: Step chart
+- **add_shaded_plot**: Filled area
+
+### Bar Charts
+- **add_bar_chart**: Vertical bars
+- **add_bar_chart_h**: Horizontal bars
+- **add_bar_group**: Grouped bars
+
+### Specialized Plots
+- **add_pie_chart**: Pie chart
+- **add_heatmap**: Heat map
+- **add_histogram**: Histogram
+- **add_error_bars**: Error bar plot
+- **add_stem_plot**: Stem plot
+- **add_digital_plot**: Digital signal
+
+---
+
+## Custom Extended Widgets
+
+### Knobs (Third-party)
+- **add_knob**: Rotary knob
+- **add_knob_float**: Float knob
+- **add_knob_int**: Integer knob
+
+### Toggles
+- **add_toggle**: Toggle switch
+- **add_toggle_animated**: Animated toggle
+
+### Spinners
+- **add_spinner**: Loading spinner
+- **add_spinner_dots**: Dot spinner
+- **add_spinner_bars**: Bar spinner
+
+### Date/Time
+- **add_date_picker**: Date selector
+- **add_time_picker**: Time selector
+- **add_calendar**: Calendar widget
+
+### Gradients
+- **add_gradient_editor**: Gradient editor
+- **add_gradient_bar**: Gradient display
+
+---
+
+## Node Editor Widgets
+
+- **create_node_editor**: Node graph canvas
+- **add_node**: Graph node
+- **add_node_input**: Input pin
+- **add_node_output**: Output pin
+- **add_link**: Node connection
+- **add_node_group**: Node group
+
+---
+
+## Text Editor Widgets
+
+- **create_text_editor**: Code editor
+- **create_markdown_editor**: Markdown editor
+- **set_syntax_highlighting**: Enable syntax
+- **set_editor_language**: Language mode
+- **add_breakpoint**: Editor breakpoint
+
+---
+
+## File Dialog Widgets
+
+### ImGuiFD
+- **open_file_dialog**: File picker
+- **open_dir_dialog**: Directory picker
+- **save_file_dialog**: Save dialog
+
+### Filters
+- **add_file_filter**: File type filter
+- **set_default_path**: Default directory
+
+---
+
+## Notification Widgets
+
+- **show_notification**: Generic toast
+- **show_success**: Success notification
+- **show_warning**: Warning notification
+- **show_error**: Error notification
+- **show_info**: Info notification
+- **set_notification_duration**: Set timeout
+- **set_notification_position**: Position config
+
+---
+
+## Memory/Hex Editor
+
+- **add_memory_editor**: Hex editor widget
+- **set_memory_data**: Load data
+- **set_memory_readonly**: Read-only mode
+- **highlight_memory_range**: Highlight bytes
+
+---
+
+## Tooltip & Popup Widgets
+
+### Tooltips
+- **add_tooltip**: Hover tooltip
+- **add_tooltip_text**: Simple text tooltip
+- **begin_tooltip**: Custom tooltip content
+
+### Popups
+- **add_popup**: Generic popup
+- **add_modal_popup**: Modal dialog
+- **add_context_menu**: Right-click menu
+- **add_popup_menu**: Popup menu
+
+---
+
+## Image & Texture Widgets
+
+- **add_image**: Display image
+- **add_image_button**: Clickable image
+- **add_texture**: Load texture
+- **set_texture_filtering**: Filter mode
+
+---
+
+## Progress & Status Widgets
+
+- **add_progress_bar**: Progress indicator
+- **add_loading_indicator**: Loading animation
+- **add_status_bar**: Status bar
+
+---
+
+## Separator & Spacing
+
+- **add_separator**: Horizontal line
+- **add_vertical_separator**: Vertical line
+- **add_spacing**: Vertical space
+- **add_dummy**: Empty space
+- **add_newline**: Force new line
+
+---
+
+## Drag & Drop
+
+- **begin_drag_drop_source**: Drag source
+- **begin_drag_drop_target**: Drop target
+- **set_drag_drop_payload**: Data payload
+- **accept_drag_drop_payload**: Accept drop
+
+---
+
+## Total Widget Count: 150+
+
+This catalog covers:
+- ✅ All ImGui core widgets
+- ✅ ImPlot visualization widgets
+- ✅ Third-party extensions (knobs, toggles, spinners)
+- ✅ File dialogs (ImGuiFD)
+- ✅ Notifications (imgui-notify)
+- ✅ Node editors
+- ✅ Text/code editors
+- ✅ Memory/hex editors
+- ✅ Custom community widgets

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,247 @@
+# Champi-Gen-UI Examples
+
+This directory contains example applications demonstrating the capabilities of Champi-Gen-UI.
+
+## Available Examples
+
+### 1. Basic Demo (`basic_demo.py`)
+A simple demonstration of basic widgets including buttons, text inputs, checkboxes, sliders, and color pickers.
+
+**Features:**
+- Basic widgets showcase
+- Simple layout
+- Widget callbacks
+- Color customization
+
+**Run it:**
+```bash
+python examples/basic_demo.py
+```
+
+### 2. Dashboard Demo (`dashboard_demo.py`)
+A comprehensive interactive dashboard showcasing advanced features and multiple widget types.
+
+**Features:**
+- ✓ Real-time statistics display
+- ✓ Performance metrics with progress bars
+- ✓ Interactive controls (checkboxes, sliders)
+- ✓ Data visualization (line & bar charts)
+- ✓ Theme customization
+- ✓ Docking layout support
+- ✓ Multiple windows
+- ✓ Collapsing sections
+- ✓ Settings panel
+- ✓ Tree views and selectables
+
+**Run it:**
+```bash
+python examples/dashboard_demo.py
+```
+
+**What you'll see:**
+1. **Main Dashboard Window** - Statistics, performance metrics, control panel
+2. **Performance Charts Window** - Line chart and bar chart for data visualization
+3. **Settings Window** - Theme selection, color customization, user preferences
+
+### 3. MCP Tools Demo (`mcp_tools_demo.md`)
+Documentation showing how to use the MCP server tools to create UIs through natural language.
+
+**This is a reference guide for:**
+- LLMs using the MCP server
+- Understanding available MCP tools
+- Common UI patterns
+- Example interactions
+
+## Running the MCP Server
+
+To use Champi-Gen-UI as an MCP server:
+
+```bash
+# Start the server
+champi-gen-ui serve
+
+# Or with UV
+uv run champi-gen-ui serve
+```
+
+Then configure your MCP client to connect to it.
+
+## Widget Gallery
+
+The examples demonstrate these widget types:
+
+### Basic Widgets
+- `TextWidget` - Display text
+- `ButtonWidget` - Interactive buttons
+- `InputTextWidget` - Text input fields
+- `CheckboxWidget` - Checkboxes
+- `SliderFloatWidget` / `SliderIntWidget` - Value sliders
+- `ColorPickerWidget` - Color selection
+- `ComboWidget` - Dropdown lists
+- `ListBoxWidget` - List selection
+
+### Display Widgets
+- `TextColoredWidget` - Colored text
+- `BulletTextWidget` - Bullet point lists
+- `HelpMarkerWidget` - Tooltip markers
+- `ProgressBarWidget` - Progress indicators
+- `PlotLinesWidget` - Simple line plots
+
+### Container Widgets
+- `WindowWidget` - Sub-windows
+- `CollapsingHeaderWidget` - Collapsible sections
+- `SeparatorWidget` - Visual separators
+
+### Menu Widgets
+- `MenuBarWidget` - Menu bars
+- `MenuWidget` - Menus
+- `MenuItemWidget` - Menu items
+- `SelectableWidget` - Selectable items
+- `TreeNodeWidget` - Tree structures
+
+### Plotting Widgets
+- `LineChartWidget` - Line charts
+- `BarChartWidget` - Bar charts
+- `ScatterPlotWidget` - Scatter plots
+- `PieChartWidget` - Pie charts
+- `HeatmapWidget` - Heatmaps
+
+## Themes
+
+All examples support multiple themes:
+
+- **Dark** - Default dark theme
+- **Light** - Light theme
+- **Cherry** - Cherry red theme
+- **Nord** - Nord color scheme (used in dashboard_demo)
+- **Dracula** - Dracula theme
+- **Gruvbox** - Gruvbox theme
+- **Solarized Dark** - Solarized dark theme
+- **Monokai** - Monokai theme
+- **Material** - Material design theme
+
+Change themes programmatically:
+```python
+theme_manager.apply_theme_by_name("nord")
+```
+
+## Canvas Modes
+
+Examples demonstrate different canvas modes:
+
+1. **Standard** (`basic_demo.py`) - Traditional window-based UI
+2. **Docking** (`dashboard_demo.py`) - Dockable window layout for complex UIs
+3. **Multi-Viewport** - Multiple windows across screens
+4. **Fullscreen** - Immersive full-screen mode
+5. **Overlay** - Transparent overlay mode
+
+## Creating Your Own UI
+
+### Method 1: Direct Python Code
+
+```python
+from champi_gen_ui.core.canvas import CanvasManager
+from champi_gen_ui.core.state import CanvasMode
+from champi_gen_ui.widgets.basic import ButtonWidget, TextWidget
+
+# Create manager
+manager = CanvasManager()
+
+# Create canvas
+canvas = manager.create_canvas(
+    canvas_id="my_app",
+    width=800,
+    height=600,
+    mode=CanvasMode.STANDARD,
+    title="My Application"
+)
+
+# Register widgets
+registry = canvas.widget_registry
+registry.factory.register("button", ButtonWidget)
+registry.factory.register("text", TextWidget)
+
+# Add widgets
+title = registry.factory.create("text", "title", text="Hello World!")
+canvas.add_widget(title)
+
+button = registry.factory.create("button", "btn1", label="Click Me", size=[120, 40])
+button.set_position(10, 40)
+canvas.add_widget(button)
+
+# Run
+canvas.run()
+```
+
+### Method 2: Using MCP Tools (via LLM)
+
+1. Start the MCP server: `champi-gen-ui serve`
+2. Connect your LLM client
+3. Ask the LLM to create UIs using natural language
+4. The LLM will use MCP tools like `create_canvas`, `add_button`, etc.
+
+See `mcp_tools_demo.md` for detailed examples.
+
+## Tips for Development
+
+1. **Start Simple**: Begin with `basic_demo.py` to understand the basics
+2. **Use Docking Mode**: For complex UIs with multiple windows
+3. **Apply Themes Early**: Set your theme before adding widgets
+4. **Widget Registration**: Remember to register widget types before using them
+5. **Callbacks**: Use `register_callback()` for interactive widgets
+6. **Position Widgets**: Use `set_position(x, y)` for manual layout
+7. **Organize with Sections**: Use collapsing headers to group related widgets
+8. **Visual Separation**: Add separators between sections
+9. **Data Binding**: Use the binding system for reactive UIs
+10. **Export Your Work**: Use `export_canvas_json()` or `export_canvas_python()` to save your UIs
+
+## Keyboard Shortcuts
+
+When running the examples:
+- **Ctrl+C** - Exit the application
+- **Mouse Drag** - Move windows (in docking mode)
+- **Window Close Button** - Close individual windows (if `closable=True`)
+
+## Troubleshooting
+
+### Issue: Window doesn't appear
+**Solution**: Ensure you're calling `canvas.run()` at the end of your script
+
+### Issue: Widgets not showing
+**Solution**:
+1. Check widget registration with `registry.factory.register()`
+2. Verify widgets are added with `canvas.add_widget()`
+3. Ensure widget visibility: `widget.state.visible = True`
+
+### Issue: Theme not applying
+**Solution**:
+1. Check theme is registered: `theme_manager.list_themes()`
+2. Use correct theme name (case-sensitive)
+3. Apply theme before creating canvas
+
+### Issue: Charts not rendering
+**Solution**:
+1. Ensure data is provided as lists: `x_data=[...]`, `y_data=[...]`
+2. Check data lengths match for paired data (x/y coordinates)
+3. Verify ImPlot is installed (should come with imgui-bundle)
+
+## Further Reading
+
+- [Main README](../README.md) - Project overview
+- [MCP Tools API](../docs/MCP_TOOLS_API.md) - Complete API reference
+- [Widget Catalog](../docs/WIDGET_CATALOG.md) - All available widgets
+- [Architecture](../docs/ARCHITECTURE.md) - System architecture
+
+## Contributing Examples
+
+Have a cool example to share? We'd love to see it!
+
+1. Create your example in this directory
+2. Follow the existing naming pattern: `{name}_demo.py`
+3. Add documentation at the top of the file
+4. Update this README with your example
+5. Submit a pull request
+
+## License
+
+These examples are part of the Champi-Gen-UI project and are licensed under the MIT License.

--- a/examples/basic_demo.py
+++ b/examples/basic_demo.py
@@ -1,0 +1,137 @@
+"""
+Basic demo showing how to use champi-gen-ui.
+
+This example creates a simple UI with various widgets.
+"""
+
+from champi_gen_ui.core.canvas import CanvasManager
+from champi_gen_ui.core.state import CanvasMode
+from champi_gen_ui.widgets.basic import (
+    ButtonWidget,
+    CheckboxWidget,
+    ColorPickerWidget,
+    InputTextWidget,
+    TextWidget,
+)
+from champi_gen_ui.widgets.slider import SliderFloatWidget
+
+
+def main():
+    """Run the basic demo."""
+    # Create canvas manager
+    manager = CanvasManager()
+
+    # Create a canvas
+    canvas = manager.create_canvas(
+        canvas_id="demo",
+        width=600,
+        height=400,
+        mode=CanvasMode.STANDARD,
+        title="Champi-Gen-UI Basic Demo",
+    )
+
+    # Register widget types
+    registry = canvas.widget_registry
+    registry.factory.register("button", ButtonWidget)
+    registry.factory.register("text", TextWidget)
+    registry.factory.register("input_text", InputTextWidget)
+    registry.factory.register("checkbox", CheckboxWidget)
+    registry.factory.register("slider_float", SliderFloatWidget)
+    registry.factory.register("color_picker", ColorPickerWidget)
+
+    # Add widgets
+    # Title text
+    title = registry.factory.create(
+        "text",
+        "title",
+        text="Welcome to Champi-Gen-UI!",
+        color=(0.2, 0.8, 0.2, 1.0),
+    )
+    title.set_position(10, 10)
+    canvas.add_widget(title)
+
+    # Description text
+    desc = registry.factory.create(
+        "text",
+        "desc",
+        text="This is a demo of the basic widgets.",
+    )
+    desc.set_position(10, 40)
+    canvas.add_widget(desc)
+
+    # Button with callback
+    def on_button_click():
+        print("Button clicked!")
+
+    button = registry.factory.create(
+        "button",
+        "btn1",
+        label="Click Me!",
+        size=[120, 30],
+    )
+    button.set_position(10, 70)
+    button.register_callback("on_click", on_button_click)
+    canvas.add_widget(button)
+
+    # Input text
+    input_field = registry.factory.create(
+        "input_text",
+        "input1",
+        label="Name",
+        value="",
+        hint="Enter your name...",
+    )
+    input_field.set_position(10, 110)
+    canvas.add_widget(input_field)
+
+    # Checkbox
+    checkbox = registry.factory.create(
+        "checkbox",
+        "check1",
+        label="Enable feature",
+        checked=False,
+    )
+    checkbox.set_position(10, 140)
+    canvas.add_widget(checkbox)
+
+    # Slider
+    slider = registry.factory.create(
+        "slider_float",
+        "slider1",
+        label="Volume",
+        value=0.5,
+        v_min=0.0,
+        v_max=1.0,
+    )
+    slider.set_position(10, 170)
+    canvas.add_widget(slider)
+
+    # Color picker
+    color_picker = registry.factory.create(
+        "color_picker",
+        "color1",
+        label="Theme Color",
+        color=(0.2, 0.5, 0.8, 1.0),
+    )
+    color_picker.set_position(10, 200)
+    canvas.add_widget(color_picker)
+
+    # Status text at bottom
+    status = registry.factory.create(
+        "text",
+        "status",
+        text="Status: Ready",
+        color=(0.7, 0.7, 0.7, 1.0),
+    )
+    status.set_position(10, 350)
+    canvas.add_widget(status)
+
+    print(f"Canvas created with {len(canvas.widget_registry.get_all())} widgets")
+    print("Press Ctrl+C to exit")
+
+    # Run the canvas
+    canvas.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dashboard_demo.py
+++ b/examples/dashboard_demo.py
@@ -1,0 +1,394 @@
+"""
+Interactive Dashboard Demo using Champi-Gen-UI.
+
+This example creates a comprehensive dashboard with various widgets including:
+- Text displays and headers
+- Interactive controls (buttons, sliders, checkboxes)
+- Data visualization (line charts, progress bars)
+- Color customization
+"""
+
+from champi_gen_ui.core.canvas import CanvasManager
+from champi_gen_ui.core.state import CanvasMode
+from champi_gen_ui.themes.manager import ThemeManager
+from champi_gen_ui.themes.presets import THEME_PRESETS
+from champi_gen_ui.widgets.basic import (
+    ButtonWidget,
+    CheckboxWidget,
+    ColorPickerWidget,
+    InputTextWidget,
+    TextWidget,
+)
+from champi_gen_ui.widgets.container import (
+    CollapsingHeaderWidget,
+    SeparatorWidget,
+    WindowWidget,
+)
+from champi_gen_ui.widgets.display import (
+    BulletTextWidget,
+    HelpMarkerWidget,
+    ProgressBarWidget,
+    TextColoredWidget,
+)
+from champi_gen_ui.widgets.menu import (
+    SelectableWidget,
+    TreeNodeWidget,
+)
+from champi_gen_ui.widgets.plotting import BarChartWidget, LineChartWidget
+from champi_gen_ui.widgets.slider import SliderFloatWidget, SliderIntWidget
+
+
+def main():
+    """Run the dashboard demo."""
+    print("=" * 60)
+    print("Champi-Gen-UI Dashboard Demo")
+    print("=" * 60)
+
+    # Create canvas manager and theme manager
+    manager = CanvasManager()
+    theme_manager = ThemeManager()
+
+    # Register theme presets
+    for _name, theme in THEME_PRESETS.items():
+        theme_manager.register_theme(theme)
+
+    # Apply a nice theme
+    theme_manager.apply_theme_by_name("nord")
+
+    # Create a docking canvas for flexible layout
+    canvas = manager.create_canvas(
+        canvas_id="dashboard",
+        width=1280,
+        height=800,
+        mode=CanvasMode.DOCKING,
+        title="Champi-Gen-UI - Interactive Dashboard Demo",
+    )
+
+    # Register all widget types
+    registry = canvas.widget_registry
+    registry.factory.register("button", ButtonWidget)
+    registry.factory.register("text", TextWidget)
+    registry.factory.register("input_text", InputTextWidget)
+    registry.factory.register("checkbox", CheckboxWidget)
+    registry.factory.register("slider_float", SliderFloatWidget)
+    registry.factory.register("slider_int", SliderIntWidget)
+    registry.factory.register("color_picker", ColorPickerWidget)
+
+    # === MAIN WINDOW ===
+    main_window = WindowWidget(
+        "main_window", title="Dashboard Overview", closable=False
+    )
+    main_window.set_position(10, 30)
+    canvas.add_widget(main_window)
+
+    # Title Section
+    title = registry.factory.create(
+        "text",
+        "title",
+        text="Dashboard Analytics",
+        color=(0.3, 0.7, 1.0, 1.0),
+    )
+    canvas.add_widget(title)
+
+    # Subtitle
+    subtitle = TextColoredWidget(
+        "subtitle",
+        text="Real-time monitoring and controls",
+        color=(0.7, 0.7, 0.7, 1.0),
+    )
+    canvas.add_widget(subtitle)
+
+    # Separator
+    separator1 = SeparatorWidget("sep1")
+    canvas.add_widget(separator1)
+
+    # === STATISTICS SECTION ===
+    stats_header = CollapsingHeaderWidget(
+        "stats_header", label="Statistics", default_open=True
+    )
+    canvas.add_widget(stats_header)
+
+    # Bullet points for stats
+    stat1 = BulletTextWidget("stat1", text="Active Users: 1,234")
+    canvas.add_widget(stat1)
+
+    stat2 = BulletTextWidget("stat2", text="Server Uptime: 99.9%")
+    canvas.add_widget(stat2)
+
+    stat3 = BulletTextWidget("stat3", text="Response Time: 45ms")
+    canvas.add_widget(stat3)
+
+    # Help marker
+    help_marker = HelpMarkerWidget(
+        "help1",
+        text="These statistics are updated in real-time from the server monitoring system.",
+        marker="(?)",
+    )
+    canvas.add_widget(help_marker)
+
+    # Separator
+    separator2 = SeparatorWidget("sep2")
+    canvas.add_widget(separator2)
+
+    # === PERFORMANCE METRICS ===
+    metrics_header = CollapsingHeaderWidget(
+        "metrics_header", label="Performance Metrics", default_open=True
+    )
+    canvas.add_widget(metrics_header)
+
+    # CPU Usage Progress Bar
+    cpu_label = registry.factory.create(
+        "text",
+        "cpu_label",
+        text="CPU Usage:",
+    )
+    canvas.add_widget(cpu_label)
+
+    cpu_progress = ProgressBarWidget("cpu_progress", fraction=0.65, overlay="65%")
+    canvas.add_widget(cpu_progress)
+
+    # Memory Usage Progress Bar
+    memory_label = registry.factory.create(
+        "text",
+        "memory_label",
+        text="Memory Usage:",
+    )
+    canvas.add_widget(memory_label)
+
+    memory_progress = ProgressBarWidget("memory_progress", fraction=0.42, overlay="42%")
+    canvas.add_widget(memory_progress)
+
+    # Disk Usage Progress Bar
+    disk_label = registry.factory.create(
+        "text",
+        "disk_label",
+        text="Disk Usage:",
+    )
+    canvas.add_widget(disk_label)
+
+    disk_progress = ProgressBarWidget("disk_progress", fraction=0.78, overlay="78%")
+    canvas.add_widget(disk_progress)
+
+    # Separator
+    separator3 = SeparatorWidget("sep3")
+    canvas.add_widget(separator3)
+
+    # === CONTROLS SECTION ===
+    controls_header = CollapsingHeaderWidget(
+        "controls_header", label="Control Panel", default_open=True
+    )
+    canvas.add_widget(controls_header)
+
+    # Enable monitoring checkbox
+    monitoring_check = registry.factory.create(
+        "checkbox",
+        "monitoring_check",
+        label="Enable Real-time Monitoring",
+        checked=True,
+    )
+    canvas.add_widget(monitoring_check)
+
+    # Auto-refresh checkbox
+    refresh_check = registry.factory.create(
+        "checkbox",
+        "refresh_check",
+        label="Auto-refresh Dashboard",
+        checked=True,
+    )
+    canvas.add_widget(refresh_check)
+
+    # Refresh rate slider
+    refresh_rate = registry.factory.create(
+        "slider_int",
+        "refresh_rate",
+        label="Refresh Rate (seconds)",
+        value=5,
+        v_min=1,
+        v_max=60,
+    )
+    canvas.add_widget(refresh_rate)
+
+    # Alert threshold slider
+    alert_threshold = registry.factory.create(
+        "slider_float",
+        "alert_threshold",
+        label="Alert Threshold",
+        value=0.85,
+        v_min=0.0,
+        v_max=1.0,
+    )
+    canvas.add_widget(alert_threshold)
+
+    # Action buttons
+    def on_refresh_click():
+        print("Dashboard refreshed!")
+
+    def on_export_click():
+        print("Data exported!")
+
+    def on_reset_click():
+        print("Settings reset!")
+
+    refresh_button = registry.factory.create(
+        "button",
+        "refresh_btn",
+        label="Refresh Now",
+        size=[120, 30],
+    )
+    refresh_button.register_callback("on_click", on_refresh_click)
+    canvas.add_widget(refresh_button)
+
+    export_button = registry.factory.create(
+        "button",
+        "export_btn",
+        label="Export Data",
+        size=[120, 30],
+    )
+    export_button.register_callback("on_click", on_export_click)
+    canvas.add_widget(export_button)
+
+    reset_button = registry.factory.create(
+        "button",
+        "reset_btn",
+        label="Reset Settings",
+        size=[120, 30],
+    )
+    reset_button.register_callback("on_click", on_reset_click)
+    canvas.add_widget(reset_button)
+
+    # === CHART WINDOW ===
+    chart_window = WindowWidget(
+        "chart_window", title="Performance Charts", closable=False
+    )
+    chart_window.set_position(450, 30)
+    canvas.add_widget(chart_window)
+
+    # Line chart for performance over time
+    performance_data_x = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    performance_data_y = [45, 52, 48, 65, 58, 71, 68, 75, 72, 78, 82]
+
+    line_chart = LineChartWidget(
+        "line_chart",
+        title="Response Time (ms)",
+        x_data=performance_data_x,
+        y_data=performance_data_y,
+    )
+    canvas.add_widget(line_chart)
+
+    # Bar chart for resource comparison
+    resource_labels = ["CPU", "Memory", "Disk", "Network"]
+    resource_values = [65.0, 42.0, 78.0, 35.0]
+
+    bar_chart = BarChartWidget(
+        "bar_chart",
+        title="Resource Utilization (%)",
+        values=resource_values,
+        labels=resource_labels,
+    )
+    canvas.add_widget(bar_chart)
+
+    # === SETTINGS WINDOW ===
+    settings_window = WindowWidget("settings_window", title="Settings", closable=True)
+    settings_window.set_position(900, 30)
+    canvas.add_widget(settings_window)
+
+    # Theme selection
+    theme_label = registry.factory.create(
+        "text",
+        "theme_label",
+        text="Theme Selection:",
+    )
+    canvas.add_widget(theme_label)
+
+    # Theme options as selectables
+    theme_dark = SelectableWidget("theme_dark", label="Dark (default)", selected=False)
+    canvas.add_widget(theme_dark)
+
+    theme_light = SelectableWidget("theme_light", label="Light", selected=False)
+    canvas.add_widget(theme_light)
+
+    theme_nord = SelectableWidget("theme_nord", label="Nord (active)", selected=True)
+    canvas.add_widget(theme_nord)
+
+    theme_dracula = SelectableWidget("theme_dracula", label="Dracula", selected=False)
+    canvas.add_widget(theme_dracula)
+
+    # Color customization
+    color_sep = SeparatorWidget("color_sep")
+    canvas.add_widget(color_sep)
+
+    accent_color = registry.factory.create(
+        "color_picker",
+        "accent_color",
+        label="Accent Color",
+        color=(0.3, 0.7, 1.0, 1.0),
+    )
+    canvas.add_widget(accent_color)
+
+    # User settings tree
+    tree_sep = SeparatorWidget("tree_sep")
+    canvas.add_widget(tree_sep)
+
+    user_settings = TreeNodeWidget(
+        "user_settings", label="User Preferences", default_open=True
+    )
+    canvas.add_widget(user_settings)
+
+    # Input for username
+    username_input = registry.factory.create(
+        "input_text",
+        "username",
+        label="Username",
+        value="admin",
+        hint="Enter username...",
+    )
+    canvas.add_widget(username_input)
+
+    # Email input
+    email_input = registry.factory.create(
+        "input_text",
+        "email",
+        label="Email",
+        value="admin@example.com",
+        hint="Enter email...",
+    )
+    canvas.add_widget(email_input)
+
+    # === STATUS BAR ===
+    status_sep = SeparatorWidget("status_sep")
+    canvas.add_widget(status_sep)
+
+    status_text = TextColoredWidget(
+        "status",
+        text="Status: System running normally | Last updated: Just now",
+        color=(0.3, 1.0, 0.3, 1.0),
+    )
+    canvas.add_widget(status_text)
+
+    # Print summary
+    print("\nCanvas created successfully!")
+    print(f"  Canvas ID: {canvas.state.canvas_id}")
+    print(f"  Mode: {canvas.state.mode.value}")
+    print(f"  Size: {canvas.state.size[0]}x{canvas.state.size[1]}")
+    print(f"  Widgets: {len(canvas.widget_registry.get_all())}")
+    print("\nActive theme: Nord")
+    print("\nDashboard Features:")
+    print("  ✓ Real-time statistics")
+    print("  ✓ Performance metrics with progress bars")
+    print("  ✓ Interactive controls (checkboxes, sliders)")
+    print("  ✓ Data visualization (line & bar charts)")
+    print("  ✓ Theme customization")
+    print("  ✓ Docking layout support")
+    print("\nPress Ctrl+C to exit")
+    print("=" * 60)
+
+    # Run the canvas
+    try:
+        canvas.run()
+    except KeyboardInterrupt:
+        print("\nShutting down dashboard...")
+        print("Goodbye!")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mcp_tools_demo.md
+++ b/examples/mcp_tools_demo.md
@@ -1,0 +1,594 @@
+# MCP Tools Demo
+
+This document demonstrates how to use the Champi-Gen-UI MCP server tools to create UIs through natural language.
+
+## How It Works
+
+1. Start the MCP server: `champi-gen-ui serve`
+2. Connect your LLM to the MCP server
+3. Use natural language to create UIs
+
+## Example Interactions
+
+### Example 1: Simple Hello World UI
+
+**User:** "Create a simple UI with a title that says 'Hello World' and a button that says 'Click Me'"
+
+**MCP Tools Executed:**
+```json
+// Create canvas
+create_canvas(
+  canvas_id="hello_world",
+  width=800,
+  height=600,
+  mode="standard",
+  title="Hello World Demo"
+)
+
+// Add title text
+add_text(
+  canvas_id="hello_world",
+  widget_id="title",
+  text="Hello World",
+  color=[0.2, 0.8, 0.2, 1.0],
+  position=[20, 20]
+)
+
+// Add button
+add_button(
+  canvas_id="hello_world",
+  widget_id="btn1",
+  label="Click Me",
+  size=[120, 40],
+  position=[20, 60]
+)
+```
+
+### Example 2: Dashboard with Charts
+
+**User:** "Create a dashboard with performance metrics showing CPU, Memory, and Disk usage as progress bars, and a line chart showing response times"
+
+**MCP Tools Executed:**
+```json
+// Create docking canvas for flexible layout
+create_canvas(
+  canvas_id="dashboard",
+  width=1280,
+  height=800,
+  mode="docking",
+  title="Performance Dashboard"
+)
+
+// Apply theme
+apply_theme(theme_name="nord")
+
+// Add title
+add_text(
+  canvas_id="dashboard",
+  widget_id="title",
+  text="Performance Dashboard",
+  color=[0.3, 0.7, 1.0, 1.0],
+  position=[10, 10]
+)
+
+// Add CPU progress bar
+add_text(
+  canvas_id="dashboard",
+  widget_id="cpu_label",
+  text="CPU Usage:",
+  position=[10, 50]
+)
+
+add_progress_bar(
+  canvas_id="dashboard",
+  widget_id="cpu_progress",
+  fraction=0.65,
+  overlay="65%"
+)
+
+// Add Memory progress bar
+add_text(
+  canvas_id="dashboard",
+  widget_id="memory_label",
+  text="Memory Usage:",
+  position=[10, 90]
+)
+
+add_progress_bar(
+  canvas_id="dashboard",
+  widget_id="memory_progress",
+  fraction=0.42,
+  overlay="42%"
+)
+
+// Add Disk progress bar
+add_text(
+  canvas_id="dashboard",
+  widget_id="disk_label",
+  text="Disk Usage:",
+  position=[10, 130]
+)
+
+add_progress_bar(
+  canvas_id="dashboard",
+  widget_id="disk_progress",
+  fraction=0.78,
+  overlay="78%"
+)
+
+// Add line chart for response times
+add_line_chart(
+  canvas_id="dashboard",
+  widget_id="response_chart",
+  title="Response Time (ms)",
+  x_data=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+  y_data=[45, 52, 48, 65, 58, 71, 68, 75, 72, 78, 82]
+)
+```
+
+### Example 3: Settings Panel
+
+**User:** "Create a settings panel with theme selection, sliders for adjusting values, and color pickers"
+
+**MCP Tools Executed:**
+```json
+// Create canvas
+create_canvas(
+  canvas_id="settings",
+  width=600,
+  height=800,
+  mode="standard",
+  title="Settings Panel"
+)
+
+// Add collapsing header for theme section
+add_collapsing_header(
+  canvas_id="settings",
+  widget_id="theme_header",
+  label="Theme Settings",
+  default_open=true
+)
+
+// Add theme selectables
+add_selectable(
+  canvas_id="settings",
+  widget_id="theme_dark",
+  label="Dark Theme",
+  selected=true
+)
+
+add_selectable(
+  canvas_id="settings",
+  widget_id="theme_light",
+  label="Light Theme",
+  selected=false
+)
+
+add_selectable(
+  canvas_id="settings",
+  widget_id="theme_nord",
+  label="Nord Theme",
+  selected=false
+)
+
+// Add separator
+add_separator(
+  canvas_id="settings",
+  widget_id="sep1"
+)
+
+// Add slider for volume
+add_slider_float(
+  canvas_id="settings",
+  widget_id="volume_slider",
+  label="Volume",
+  value=0.75,
+  v_min=0.0,
+  v_max=1.0
+)
+
+// Add slider for brightness
+add_slider_int(
+  canvas_id="settings",
+  widget_id="brightness_slider",
+  label="Brightness",
+  value=80,
+  v_min=0,
+  v_max=100
+)
+
+// Add color picker for accent color
+add_color_picker(
+  canvas_id="settings",
+  widget_id="accent_color",
+  label="Accent Color",
+  color=[0.3, 0.7, 1.0, 1.0]
+)
+
+// Add checkboxes
+add_checkbox(
+  canvas_id="settings",
+  widget_id="auto_save",
+  label="Auto-save settings",
+  checked=true
+)
+
+add_checkbox(
+  canvas_id="settings",
+  widget_id="notifications",
+  label="Enable notifications",
+  checked=false
+)
+```
+
+### Example 4: Data Visualization
+
+**User:** "Create a data visualization UI with different chart types: line chart, bar chart, scatter plot, and pie chart"
+
+**MCP Tools Executed:**
+```json
+// Create large canvas
+create_canvas(
+  canvas_id="viz",
+  width=1600,
+  height=900,
+  mode="docking",
+  title="Data Visualization"
+)
+
+// Add line chart
+add_line_chart(
+  canvas_id="viz",
+  widget_id="line_chart",
+  title="Sales Trend",
+  x_data=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  y_data=[120, 135, 128, 145, 152, 168, 175, 182, 198, 215, 225, 240]
+)
+
+// Add bar chart
+add_bar_chart(
+  canvas_id="viz",
+  widget_id="bar_chart",
+  title="Quarterly Revenue",
+  values=[125000, 148000, 165000, 182000],
+  labels=["Q1", "Q2", "Q3", "Q4"]
+)
+
+// Add scatter plot
+add_scatter_plot(
+  canvas_id="viz",
+  widget_id="scatter_plot",
+  title="User Engagement",
+  x_data=[10, 20, 30, 40, 50, 60, 70, 80, 90],
+  y_data=[15, 25, 35, 42, 55, 65, 72, 85, 95]
+)
+
+// Add pie chart
+add_pie_chart(
+  canvas_id="viz",
+  widget_id="pie_chart",
+  values=[35, 25, 20, 15, 5],
+  labels=["Direct", "Organic", "Referral", "Social", "Other"]
+)
+
+// Add controls
+add_button(
+  canvas_id="viz",
+  widget_id="refresh_btn",
+  label="Refresh Data",
+  size=[150, 40]
+)
+
+add_button(
+  canvas_id="viz",
+  widget_id="export_btn",
+  label="Export Charts",
+  size=[150, 40]
+)
+```
+
+### Example 5: Interactive Form
+
+**User:** "Create a user registration form with input fields for name, email, password, a checkbox for terms acceptance, and a submit button"
+
+**MCP Tools Executed:**
+```json
+// Create canvas
+create_canvas(
+  canvas_id="registration",
+  width=500,
+  height=600,
+  mode="standard",
+  title="User Registration"
+)
+
+// Apply theme
+apply_theme(theme_name="material")
+
+// Add header
+add_text(
+  canvas_id="registration",
+  widget_id="header",
+  text="Create Account",
+  color=[0.2, 0.6, 1.0, 1.0]
+)
+
+// Add name input
+add_input_text(
+  canvas_id="registration",
+  widget_id="name_input",
+  label="Full Name",
+  value="",
+  hint="Enter your full name"
+)
+
+// Add email input
+add_input_text(
+  canvas_id="registration",
+  widget_id="email_input",
+  label="Email",
+  value="",
+  hint="your@email.com"
+)
+
+// Add password input
+add_input_text(
+  canvas_id="registration",
+  widget_id="password_input",
+  label="Password",
+  value="",
+  hint="Enter password"
+)
+
+// Add separator
+add_separator(
+  canvas_id="registration",
+  widget_id="sep1"
+)
+
+// Add terms checkbox
+add_checkbox(
+  canvas_id="registration",
+  widget_id="terms_check",
+  label="I agree to the Terms and Conditions",
+  checked=false
+)
+
+// Add privacy checkbox
+add_checkbox(
+  canvas_id="registration",
+  widget_id="privacy_check",
+  label="I accept the Privacy Policy",
+  checked=false
+)
+
+// Add separator
+add_separator(
+  canvas_id="registration",
+  widget_id="sep2"
+)
+
+// Add submit button
+add_button(
+  canvas_id="registration",
+  widget_id="submit_btn",
+  label="Create Account",
+  size=[200, 40]
+)
+
+// Add help marker
+add_help_marker(
+  canvas_id="registration",
+  widget_id="help1",
+  text="All fields are required. Password must be at least 8 characters.",
+  marker="(?)"
+)
+```
+
+## Advanced Features
+
+### Animations
+
+```json
+// Create animation for a widget
+create_animation(
+  name="fade_in",
+  start_value=0.0,
+  end_value=1.0,
+  duration=1.5,
+  easing="ease_in_out_cubic",
+  loop=false
+)
+
+// Start the animation
+start_animation(name="fade_in")
+
+// Get current animation value
+get_animation_value(name="fade_in")
+```
+
+### Data Binding
+
+```json
+// Set data in store
+set_data(path="user.name", value="John Doe")
+set_data(path="user.email", value="john@example.com")
+
+// Bind data to widget
+bind_data(
+  source_path="user.name",
+  target_widget="name_input",
+  target_property="value",
+  bidirectional=true
+)
+```
+
+### Notifications
+
+```json
+// Show notification
+show_notification(
+  title="Success",
+  message="Profile updated successfully!",
+  type="success",
+  duration=3.0
+)
+
+// Show different notification types
+show_notification(
+  title="Warning",
+  message="Low disk space",
+  type="warning",
+  duration=5.0
+)
+
+show_notification(
+  title="Error",
+  message="Failed to connect to server",
+  type="error",
+  duration=5.0
+)
+```
+
+### File Dialogs
+
+```json
+// Add file dialog button
+add_file_dialog(
+  canvas_id="main",
+  widget_id="file_dialog",
+  button_label="Open File...",
+  mode="open_file",
+  title="Select a file",
+  filters=["*.txt", "*.py", "*.json"]
+)
+
+// Show message dialog
+show_message_dialog(
+  title="Confirmation",
+  message="Are you sure you want to delete this file?",
+  type="warning"
+)
+```
+
+### Layout Management
+
+```json
+// Set layout mode
+set_layout_mode(mode="vertical")
+
+// Set spacing
+set_layout_spacing(spacing=10.0)
+```
+
+### Export/Import
+
+```json
+// Export canvas to JSON
+export_canvas_json(
+  canvas_id="dashboard",
+  filepath="dashboard.json"
+)
+
+// Export canvas to Python code
+export_canvas_python(
+  canvas_id="dashboard",
+  filepath="dashboard.py"
+)
+
+// Import canvas from JSON
+import_canvas_json(filepath="dashboard.json")
+
+// Generate code for canvas
+generate_canvas_code(canvas_id="dashboard")
+```
+
+### Templates
+
+```json
+// Save canvas as template
+save_template(
+  name="dashboard_template",
+  canvas_id="dashboard",
+  description="Standard dashboard layout with charts"
+)
+
+// Load template
+load_template(name="dashboard_template")
+
+// List templates
+list_templates()
+
+// Delete template
+delete_template(name="old_template")
+```
+
+## Available Themes
+
+- `dark` - Default dark theme
+- `light` - Light theme
+- `cherry` - Cherry red theme
+- `nord` - Nord color scheme
+- `dracula` - Dracula theme
+- `gruvbox` - Gruvbox theme
+- `solarized_dark` - Solarized dark theme
+- `monokai` - Monokai theme
+- `material` - Material design theme
+
+## Canvas Modes
+
+- `standard` - Traditional window-based UI
+- `docking` - Dockable window layout (recommended for dashboards)
+- `multi_viewport` - Multiple windows support
+- `fullscreen` - Immersive full-screen mode
+- `overlay` - Transparent overlay mode
+
+## Tips for LLMs
+
+1. **Always create a canvas first** before adding widgets
+2. **Use appropriate canvas modes**: `docking` for dashboards, `standard` for simple UIs
+3. **Apply themes early** for consistent styling
+4. **Use positions** to layout widgets manually, or use layout managers
+5. **Group related widgets** under collapsing headers or windows
+6. **Add separators** between sections for visual clarity
+7. **Use help markers** to provide tooltips
+8. **Choose appropriate chart types** based on the data
+9. **Set widget sizes** explicitly for buttons and inputs
+10. **Use data binding** for reactive UIs
+
+## Common Patterns
+
+### Dashboard Pattern
+```
+1. Create docking canvas
+2. Apply theme
+3. Create main window
+4. Add title and subtitle
+5. Add collapsing headers for sections
+6. Add progress bars, charts, and metrics
+7. Add control panel with checkboxes and sliders
+8. Add action buttons
+9. Add status bar at bottom
+```
+
+### Form Pattern
+```
+1. Create standard canvas
+2. Add header text
+3. Add input fields
+4. Add validation indicators
+5. Add checkboxes for agreements
+6. Add separator
+7. Add submit button
+8. Add help markers
+```
+
+### Visualization Pattern
+```
+1. Create large docking canvas
+2. Add multiple chart widgets
+3. Add legend/labels
+4. Add data controls (sliders, dropdowns)
+5. Add export buttons
+6. Use tooltips for data points
+```

--- a/examples/quick_demo.py
+++ b/examples/quick_demo.py
@@ -1,0 +1,304 @@
+"""
+Quick UI Demo - A simple interactive UI to demonstrate Champi-Gen-UI
+"""
+
+from champi_gen_ui.core.canvas import CanvasManager
+from champi_gen_ui.core.state import CanvasMode
+from champi_gen_ui.themes.manager import ThemeManager
+from champi_gen_ui.themes.presets import THEME_PRESETS
+from champi_gen_ui.widgets.basic import (
+    ButtonWidget,
+    CheckboxWidget,
+    ColorPickerWidget,
+    InputTextWidget,
+    TextWidget,
+)
+from champi_gen_ui.widgets.display import (
+    BulletTextWidget,
+    ProgressBarWidget,
+    TextColoredWidget,
+)
+from champi_gen_ui.widgets.plotting import BarChartWidget, LineChartWidget
+from champi_gen_ui.widgets.slider import SliderFloatWidget, SliderIntWidget
+
+
+def main():
+    """Run a quick demo UI."""
+    print("\n" + "=" * 70)
+    print("🎨 CHAMPI-GEN-UI - Interactive Demo")
+    print("=" * 70)
+
+    # Create managers
+    manager = CanvasManager()
+    theme_manager = ThemeManager()
+
+    # Register themes
+    for _name, theme in THEME_PRESETS.items():
+        theme_manager.register_theme(theme)
+
+    # Apply Dracula theme
+    try:
+        theme_manager.apply_theme_by_name("Dracula")
+        print("✓ Applied Dracula theme")
+    except Exception as e:
+        print(f"⚠ Using default theme: {e}")
+
+    # Create canvas
+    print("✓ Creating canvas...")
+    canvas = manager.create_canvas(
+        canvas_id="quick_demo",
+        width=900,
+        height=700,
+        mode=CanvasMode.STANDARD,
+        title="🎨 Champi-Gen-UI Quick Demo",
+    )
+
+    # Register widget types
+    registry = canvas.widget_registry
+    registry.factory.register("button", ButtonWidget)
+    registry.factory.register("text", TextWidget)
+    registry.factory.register("input_text", InputTextWidget)
+    registry.factory.register("checkbox", CheckboxWidget)
+    registry.factory.register("slider_float", SliderFloatWidget)
+    registry.factory.register("slider_int", SliderIntWidget)
+    registry.factory.register("color_picker", ColorPickerWidget)
+    print("✓ Registered widget types")
+
+    # === UI CREATION ===
+    print("✓ Building UI...")
+
+    # Title
+    title = TextColoredWidget(
+        "title",
+        text="🎨 Welcome to Champi-Gen-UI!",
+        color=(0.5, 0.8, 1.0, 1.0),
+    )
+    canvas.add_widget(title)
+
+    # Description
+    desc = registry.factory.create(
+        "text",
+        "desc",
+        text="A powerful UI generation system using ImGui and Python",
+    )
+    canvas.add_widget(desc)
+
+    # === INTERACTIVE SECTION ===
+    section1 = TextColoredWidget(
+        "section1",
+        text="📝 Interactive Controls",
+        color=(1.0, 0.8, 0.2, 1.0),
+    )
+    canvas.add_widget(section1)
+
+    # Name input
+    name_input = registry.factory.create(
+        "input_text",
+        "name_input",
+        label="Your Name",
+        value="",
+        hint="Enter your name...",
+    )
+    canvas.add_widget(name_input)
+
+    # Email input
+    email_input = registry.factory.create(
+        "input_text",
+        "email_input",
+        label="Email",
+        value="",
+        hint="your@email.com",
+    )
+    canvas.add_widget(email_input)
+
+    # Checkbox
+    checkbox = registry.factory.create(
+        "checkbox",
+        "subscribe_check",
+        label="Subscribe to newsletter",
+        checked=True,
+    )
+    canvas.add_widget(checkbox)
+
+    # === SLIDERS ===
+    section2 = TextColoredWidget(
+        "section2",
+        text="🎚️ Sliders & Controls",
+        color=(0.2, 1.0, 0.6, 1.0),
+    )
+    canvas.add_widget(section2)
+
+    # Volume slider
+    volume_slider = registry.factory.create(
+        "slider_float",
+        "volume",
+        label="Volume",
+        value=0.75,
+        v_min=0.0,
+        v_max=1.0,
+    )
+    canvas.add_widget(volume_slider)
+
+    # Brightness slider
+    brightness_slider = registry.factory.create(
+        "slider_int",
+        "brightness",
+        label="Brightness",
+        value=85,
+        v_min=0,
+        v_max=100,
+    )
+    canvas.add_widget(brightness_slider)
+
+    # Color picker
+    color_picker = registry.factory.create(
+        "color_picker",
+        "theme_color",
+        label="Theme Color",
+        color=(0.5, 0.3, 0.9, 1.0),
+    )
+    canvas.add_widget(color_picker)
+
+    # === PROGRESS BARS ===
+    section3 = TextColoredWidget(
+        "section3",
+        text="📊 Progress & Metrics",
+        color=(1.0, 0.5, 0.8, 1.0),
+    )
+    canvas.add_widget(section3)
+
+    # CPU usage
+    cpu_label = registry.factory.create("text", "cpu_label", text="CPU Usage:")
+    canvas.add_widget(cpu_label)
+
+    cpu_progress = ProgressBarWidget("cpu_bar", fraction=0.67, overlay="67%")
+    canvas.add_widget(cpu_progress)
+
+    # Memory usage
+    mem_label = registry.factory.create("text", "mem_label", text="Memory Usage:")
+    canvas.add_widget(mem_label)
+
+    mem_progress = ProgressBarWidget("mem_bar", fraction=0.43, overlay="43%")
+    canvas.add_widget(mem_progress)
+
+    # === DATA VISUALIZATION ===
+    section4 = TextColoredWidget(
+        "section4",
+        text="📈 Data Visualization",
+        color=(0.3, 0.9, 1.0, 1.0),
+    )
+    canvas.add_widget(section4)
+
+    # Line chart
+    line_chart = LineChartWidget(
+        "performance_chart",
+        title="Performance Over Time",
+        x_data=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        y_data=[20, 35, 28, 45, 52, 48, 65, 58, 72, 68],
+    )
+    canvas.add_widget(line_chart)
+
+    # Bar chart
+    bar_chart = BarChartWidget(
+        "resources_chart",
+        title="Resource Usage",
+        values=[67.0, 43.0, 89.0, 52.0],
+        labels=["CPU", "Memory", "Disk", "Network"],
+    )
+    canvas.add_widget(bar_chart)
+
+    # === FEATURES LIST ===
+    section5 = TextColoredWidget(
+        "section5",
+        text="✨ Features",
+        color=(1.0, 1.0, 0.3, 1.0),
+    )
+    canvas.add_widget(section5)
+
+    features = [
+        "200+ MCP Tools for UI generation",
+        "150+ Widget types from ImGui",
+        "Multiple themes (Dracula, Nord, Material, etc.)",
+        "Data binding and animations",
+        "Export to JSON or Python code",
+    ]
+
+    for i, feature in enumerate(features):
+        bullet = BulletTextWidget(f"feature_{i}", text=feature)
+        canvas.add_widget(bullet)
+
+    # === BUTTONS ===
+    def on_click():
+        print("🎉 Button clicked!")
+
+    def on_refresh():
+        print("🔄 Refreshing data...")
+
+    def on_export():
+        print("💾 Exporting UI...")
+
+    click_btn = registry.factory.create(
+        "button",
+        "click_btn",
+        label="Click Me! 🎯",
+        size=[150, 40],
+    )
+    click_btn.register_callback("on_click", on_click)
+    canvas.add_widget(click_btn)
+
+    refresh_btn = registry.factory.create(
+        "button",
+        "refresh_btn",
+        label="Refresh Data 🔄",
+        size=[150, 40],
+    )
+    refresh_btn.register_callback("on_click", on_refresh)
+    canvas.add_widget(refresh_btn)
+
+    export_btn = registry.factory.create(
+        "button",
+        "export_btn",
+        label="Export UI 💾",
+        size=[150, 40],
+    )
+    export_btn.register_callback("on_click", on_export)
+    canvas.add_widget(export_btn)
+
+    # Status
+    status = TextColoredWidget(
+        "status",
+        text="✓ All systems operational | Press Ctrl+C to exit",
+        color=(0.3, 1.0, 0.3, 1.0),
+    )
+    canvas.add_widget(status)
+
+    # Print summary
+    print(f"\n{'─' * 70}")
+    print("🎨 UI Created Successfully!")
+    print(f"{'─' * 70}")
+    print(f"  Canvas ID: {canvas.state.canvas_id}")
+    print(f"  Mode: {canvas.state.mode.value}")
+    print(f"  Size: {canvas.state.size[0]}x{canvas.state.size[1]}")
+    print(f"  Widgets: {len(canvas.widget_registry.get_all())}")
+    print(f"{'─' * 70}")
+    print("\n🎮 Interact with the UI:")
+    print("  • Fill in the name and email fields")
+    print("  • Adjust the volume and brightness sliders")
+    print("  • Pick your favorite color")
+    print("  • Click the buttons to see console output")
+    print("  • View the live charts and progress bars")
+    print(f"\n{'─' * 70}")
+    print("Press Ctrl+C to exit")
+    print(f"{'─' * 70}\n")
+
+    # Run the canvas
+    try:
+        canvas.run()
+    except KeyboardInterrupt:
+        print("\n\n" + "=" * 70)
+        print("👋 Thank you for trying Champi-Gen-UI!")
+        print("=" * 70)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/test_mcp_rendering.py
+++ b/examples/test_mcp_rendering.py
@@ -1,0 +1,148 @@
+"""
+Test script to verify MCP-driven UI rendering works correctly.
+
+This simulates what an LLM would do via MCP tools to create a UI.
+"""
+
+import time
+
+from champi_gen_ui.core.canvas import CanvasManager
+from champi_gen_ui.core.state import CanvasMode
+from champi_gen_ui.widgets.basic import (
+    ButtonWidget,
+    CheckboxWidget,
+    InputTextWidget,
+    TextWidget,
+)
+from champi_gen_ui.widgets.slider import SliderFloatWidget
+from loguru import logger
+
+# Create canvas manager
+canvas_manager = CanvasManager()
+
+
+def test_mcp_rendering():
+    """Test that MCP tools create visible UI."""
+    logger.info("Starting MCP rendering test...")
+
+    # Step 1: Create a canvas (should auto-start)
+    logger.info("Creating canvas...")
+    canvas = canvas_manager.create_canvas(
+        canvas_id="test_canvas",
+        width=800,
+        height=600,
+        mode=CanvasMode.STANDARD,
+        title="MCP Test UI",
+        auto_start=True,
+    )
+
+    # Register widget types
+    registry = canvas.widget_registry
+    registry.factory.register("button", ButtonWidget)
+    registry.factory.register("text", TextWidget)
+    registry.factory.register("input_text", InputTextWidget)
+    registry.factory.register("checkbox", CheckboxWidget)
+    registry.factory.register("slider_float", SliderFloatWidget)
+
+    logger.info(f"Canvas created and running: {canvas._running}")
+
+    # Give the canvas time to initialize
+    time.sleep(0.5)
+
+    # Step 2: Add widgets directly to canvas
+    logger.info("Adding widgets...")
+
+    # Title
+    title = registry.factory.create(
+        "text",
+        "title",
+        text="MCP Rendering Test",
+        color=(0.2, 0.8, 0.2, 1.0),
+    )
+    title.set_position(10, 10)
+    canvas.add_widget(title)
+
+    # Description
+    desc = registry.factory.create(
+        "text",
+        "desc",
+        text="This UI was created programmatically!",
+    )
+    desc.set_position(10, 40)
+    canvas.add_widget(desc)
+
+    # Button
+    button = registry.factory.create(
+        "button",
+        "btn1",
+        label="Click Me!",
+        size=[120, 30],
+    )
+    button.set_position(10, 70)
+    canvas.add_widget(button)
+
+    # Input field
+    input_field = registry.factory.create(
+        "input_text",
+        "input1",
+        label="Name",
+        value="",
+        hint="Enter your name...",
+    )
+    input_field.set_position(10, 110)
+    canvas.add_widget(input_field)
+
+    # Checkbox
+    checkbox = registry.factory.create(
+        "checkbox",
+        "check1",
+        label="Enable feature",
+        checked=False,
+    )
+    checkbox.set_position(10, 140)
+    canvas.add_widget(checkbox)
+
+    # Slider
+    slider = registry.factory.create(
+        "slider_float",
+        "slider1",
+        label="Volume",
+        value=0.5,
+        v_min=0.0,
+        v_max=1.0,
+    )
+    slider.set_position(10, 170)
+    canvas.add_widget(slider)
+
+    logger.info("Widgets added! UI should be visible now.")
+
+    # Get canvas state
+    canvas = canvas_manager.get_canvas("test_canvas")
+    if canvas:
+        logger.info(f"Canvas running: {canvas._running}")
+        logger.info(f"Widget count: {len(canvas.widget_registry.get_all())}")
+        logger.info(f"Widgets: {list(canvas.widget_registry.get_all().keys())}")
+
+    # Keep test running for 30 seconds to view the UI
+    logger.info("Test will run for 30 seconds. Check that the UI window is visible!")
+    logger.info("The window should show:")
+    logger.info("  - Title text in green")
+    logger.info("  - Description text")
+    logger.info("  - Button labeled 'Click Me!'")
+    logger.info("  - Input field with hint text")
+    logger.info("  - Checkbox")
+    logger.info("  - Slider")
+
+    try:
+        time.sleep(30)
+    except KeyboardInterrupt:
+        logger.info("Test interrupted by user")
+
+    # Cleanup
+    logger.info("Stopping canvas...")
+    canvas_manager.stop_all()
+    logger.info("Test complete!")
+
+
+if __name__ == "__main__":
+    test_mcp_rendering()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,9 @@ skips = ["B101", "B601"]
 dev = [
     "mypy>=1.18.2",
     "pre-commit>=4.3.0",
+    "pytest>=8.4.2",
+    "pytest-asyncio>=1.2.0",
+    "pytest-cov>=7.0.0",
 ]
 # B101: assert_used (allowed in tests)
 # B601: paramiko_calls (not applicable)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,8 +144,15 @@ strict_equality = true
 module = [
     "imgui_bundle.*",
     "pyglm.*",
+    "champi_gen_ui.*",
+    "pytest",
+    "_pytest.*",
 ]
 ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["examples.*"]
+ignore_errors = true
 
 # Pytest configuration
 [tool.pytest.ini_options]
@@ -210,5 +217,11 @@ bump_message = "bump: version $current_version → $new_version"
 [tool.bandit]
 exclude_dirs = ["tests", "examples", ".venv", "venv"]
 skips = ["B101", "B601"]
+
+[dependency-groups]
+dev = [
+    "mypy>=1.18.2",
+    "pre-commit>=4.3.0",
+]
 # B101: assert_used (allowed in tests)
 # B601: paramiko_calls (not applicable)

--- a/src/champi_imgui/core/__init__.py
+++ b/src/champi_imgui/core/__init__.py
@@ -1,6 +1,15 @@
-"""Core module for Canvas state and management."""
+"""Core module for Canvas state, widget infrastructure, and management."""
 
 from champi_imgui.core.canvas import Canvas, CanvasManager
-from champi_imgui.core.state import CanvasState
+from champi_imgui.core.state import CanvasState, WidgetState
+from champi_imgui.core.widget import Widget, WidgetFactory, WidgetRegistry
 
-__all__ = ["Canvas", "CanvasManager", "CanvasState"]
+__all__ = [
+    "Canvas",
+    "CanvasManager",
+    "CanvasState",
+    "Widget",
+    "WidgetFactory",
+    "WidgetRegistry",
+    "WidgetState",
+]

--- a/src/champi_imgui/core/state.py
+++ b/src/champi_imgui/core/state.py
@@ -1,10 +1,12 @@
-"""Canvas state management using dataclasses.
+"""Canvas and widget state management using dataclasses.
 
-Defines the core state structure for Canvas instances.
+Defines the core state structures for Canvas and Widget instances.
 """
 
 from dataclasses import dataclass, field
 from typing import Any
+
+import blinker
 
 
 @dataclass
@@ -35,6 +37,9 @@ class CanvasState:
     properties: dict[str, Any] = field(default_factory=dict)
     """Additional canvas properties (extensible)"""
 
+    widgets: dict[str, "WidgetState"] = field(default_factory=dict)
+    """Widget states managed by this canvas"""
+
     def to_dict(self) -> dict[str, Any]:
         """Convert state to dictionary for serialization.
 
@@ -49,6 +54,7 @@ class CanvasState:
             "visible": self.visible,
             "fps_target": self.fps_target,
             "properties": self.properties,
+            "widgets": {wid: wstate.to_dict() for wid, wstate in self.widgets.items()},
         }
 
     @classmethod
@@ -74,3 +80,72 @@ class CanvasState:
             fps_target=data.get("fps_target", 60),
             properties=data.get("properties", {}),
         )
+
+
+@dataclass
+class WidgetState:
+    """State for a widget instance.
+
+    Tracks all configuration and runtime state for individual widgets.
+    """
+
+    widget_id: str
+    """Unique identifier for the widget"""
+
+    widget_type: str
+    """Type of widget (e.g., 'button', 'text', 'slider')"""
+
+    properties: dict[str, Any] = field(default_factory=dict)
+    """Widget-specific properties"""
+
+    position: tuple[float, float] | None = None
+    """Widget position (x, y) in pixels. None = auto-layout"""
+
+    size: tuple[float, float] | None = None
+    """Widget size (width, height) in pixels. None = auto-size"""
+
+    visible: bool = True
+    """Whether the widget is visible"""
+
+    enabled: bool = True
+    """Whether the widget is enabled for interaction"""
+
+    parent: str | None = None
+    """Parent widget ID for hierarchical widgets"""
+
+    children: list[str] = field(default_factory=list)
+    """Child widget IDs for container widgets"""
+
+    callbacks: dict[str, str] = field(default_factory=dict)
+    """Registered callback names by event type"""
+
+    data_bindings: dict[str, Any] = field(default_factory=dict)
+    """Data binding configuration"""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert state to dictionary for serialization.
+
+        Returns:
+            Dictionary representation of widget state
+        """
+        return {
+            "widget_id": self.widget_id,
+            "widget_type": self.widget_type,
+            "properties": self.properties.copy(),
+            "position": list(self.position) if self.position else None,
+            "size": list(self.size) if self.size else None,
+            "visible": self.visible,
+            "enabled": self.enabled,
+            "parent": self.parent,
+            "children": self.children.copy(),
+            "callbacks": self.callbacks.copy(),
+            "data_bindings": self.data_bindings.copy(),
+        }
+
+
+# Signals for state changes (using blinker for event system)
+widget_created = blinker.signal("widget-created")
+widget_updated = blinker.signal("widget-updated")
+widget_deleted = blinker.signal("widget-deleted")
+canvas_updated = blinker.signal("canvas-updated")
+state_changed = blinker.signal("state-changed")

--- a/src/champi_imgui/core/widget.py
+++ b/src/champi_imgui/core/widget.py
@@ -1,0 +1,255 @@
+"""Base widget class and registry.
+
+Defines the core Widget ABC, WidgetFactory for widget creation,
+and WidgetRegistry for widget lifecycle management.
+"""
+
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import Any
+
+from loguru import logger
+
+from champi_imgui.core.state import WidgetState, widget_created, widget_updated
+
+
+class Widget(ABC):
+    """Base class for all widgets.
+
+    All widget types must inherit from this class and implement
+    the abstract render() method.
+    """
+
+    def __init__(self, widget_id: str, **props):
+        """Initialize widget with ID and properties.
+
+        Args:
+            widget_id: Unique identifier for the widget
+            **props: Widget-specific properties
+        """
+        self.widget_id = widget_id
+        self.state = WidgetState(
+            widget_id=widget_id, widget_type=self.__class__.__name__, properties=props
+        )
+        self._callbacks: dict[str, Callable] = {}
+
+    @abstractmethod
+    def render(self) -> Any:
+        """Render the widget using ImGui calls.
+
+        This method must be implemented by all widget subclasses.
+        It should contain the ImGui rendering logic for the widget.
+
+        Returns:
+            Widget-specific return value (e.g., click state for Button,
+            current value for Slider, etc.)
+        """
+        pass
+
+    def update(self, **props) -> None:
+        """Update widget properties.
+
+        Args:
+            **props: Properties to update
+        """
+        self.state.properties.update(props)
+        widget_updated.send(self, widget=self)
+        logger.debug(f"Updated widget {self.widget_id} with {props}")
+
+    def set_visible(self, visible: bool) -> None:
+        """Set widget visibility.
+
+        Args:
+            visible: Whether the widget should be visible
+        """
+        self.state.visible = visible
+
+    def set_enabled(self, enabled: bool) -> None:
+        """Set widget enabled state.
+
+        Args:
+            enabled: Whether the widget should be enabled for interaction
+        """
+        self.state.enabled = enabled
+
+    def set_position(self, x: float, y: float) -> None:
+        """Set widget position.
+
+        Args:
+            x: X coordinate in pixels
+            y: Y coordinate in pixels
+        """
+        self.state.position = (x, y)
+
+    def set_size(self, width: float, height: float) -> None:
+        """Set widget size.
+
+        Args:
+            width: Width in pixels
+            height: Height in pixels
+        """
+        self.state.size = (width, height)
+
+    def register_callback(self, event: str, callback: Callable) -> None:
+        """Register a callback function for an event.
+
+        Args:
+            event: Event name (e.g., 'click', 'change', 'hover')
+            callback: Callback function to invoke
+        """
+        self._callbacks[event] = callback
+        self.state.callbacks[event] = callback.__name__
+
+    def trigger_callback(self, event: str, *args, **kwargs) -> Any:
+        """Trigger a registered callback.
+
+        Args:
+            event: Event name
+            *args: Positional arguments for callback
+            **kwargs: Keyword arguments for callback
+
+        Returns:
+            Callback return value, or None if no callback registered
+        """
+        if event in self._callbacks:
+            return self._callbacks[event](*args, **kwargs)
+        return None
+
+    def serialize(self) -> dict[str, Any]:
+        """Serialize widget state to dictionary.
+
+        Returns:
+            Dictionary representation of widget state
+        """
+        return self.state.to_dict()
+
+
+class WidgetFactory:
+    """Factory for creating widget instances.
+
+    Maintains a registry of widget types and creates instances on demand.
+    """
+
+    def __init__(self):
+        """Initialize factory with empty creator registry."""
+        self._creators: dict[str, type[Widget]] = {}
+
+    def register(self, widget_type: str, creator: type[Widget]) -> None:
+        """Register a widget creator class.
+
+        Args:
+            widget_type: String identifier for the widget type
+                         (e.g., 'button', 'text', 'slider')
+            creator: Widget class to use for creating instances
+        """
+        self._creators[widget_type] = creator
+        logger.info(f"Registered widget type: {widget_type}")
+
+    def create(self, widget_type: str, widget_id: str, **props) -> Widget:
+        """Create a widget instance.
+
+        Args:
+            widget_type: Type of widget to create
+            widget_id: Unique identifier for the new widget
+            **props: Widget-specific properties
+
+        Returns:
+            Created widget instance
+
+        Raises:
+            ValueError: If widget_type is not registered
+        """
+        creator = self._creators.get(widget_type)
+        if not creator:
+            raise ValueError(f"Unknown widget type: {widget_type}")
+
+        widget = creator(widget_id, **props)
+        widget_created.send(self, widget=widget)
+        logger.debug(f"Created widget {widget_id} of type {widget_type}")
+        return widget
+
+    def list_types(self) -> list[str]:
+        """List all registered widget types.
+
+        Returns:
+            List of registered widget type names
+        """
+        return list(self._creators.keys())
+
+
+class WidgetRegistry:
+    """Registry for managing widget instances.
+
+    Maintains a collection of widget instances and provides
+    access to the widget factory.
+    """
+
+    def __init__(self):
+        """Initialize registry with empty widget collection."""
+        self._widgets: dict[str, Widget] = {}
+        self._factory = WidgetFactory()
+
+    @property
+    def factory(self) -> WidgetFactory:
+        """Get the widget factory.
+
+        Returns:
+            WidgetFactory instance for creating widgets
+        """
+        return self._factory
+
+    def add(self, widget: Widget) -> None:
+        """Add a widget to the registry.
+
+        Args:
+            widget: Widget instance to add
+        """
+        self._widgets[widget.widget_id] = widget
+        logger.debug(f"Added widget {widget.widget_id} to registry")
+
+    def get(self, widget_id: str) -> Widget | None:
+        """Get a widget by ID.
+
+        Args:
+            widget_id: Widget identifier
+
+        Returns:
+            Widget instance if found, None otherwise
+        """
+        return self._widgets.get(widget_id)
+
+    def remove(self, widget_id: str) -> bool:
+        """Remove a widget from the registry.
+
+        Args:
+            widget_id: Widget identifier
+
+        Returns:
+            True if widget was removed, False if not found
+        """
+        if widget_id in self._widgets:
+            del self._widgets[widget_id]
+            logger.debug(f"Removed widget {widget_id} from registry")
+            return True
+        return False
+
+    def list(self) -> list[str]:
+        """List all widget IDs.
+
+        Returns:
+            List of widget identifiers
+        """
+        return list(self._widgets.keys())
+
+    def get_all(self) -> dict[str, Widget]:
+        """Get all widgets.
+
+        Returns:
+            Dictionary mapping widget IDs to Widget instances
+        """
+        return self._widgets.copy()
+
+    def clear(self) -> None:
+        """Clear all widgets from the registry."""
+        self._widgets.clear()
+        logger.debug("Cleared widget registry")

--- a/src/champi_imgui/widgets/__init__.py
+++ b/src/champi_imgui/widgets/__init__.py
@@ -1,0 +1,84 @@
+"""Widget implementations for champi-imgui.
+
+This package contains all widget implementations organized by category:
+- basic: Basic I/O widgets (buttons, text, checkboxes, etc.)
+- input: Advanced input widgets (combos, lists, etc.)
+- color: Color picker and editor widgets
+- progress: Progress bars and loading indicators
+"""
+
+from champi_imgui.widgets.basic import (
+    ArrowButtonWidget,
+    BulletTextWidget,
+    BulletWidget,
+    ButtonWidget,
+    CheckboxWidget,
+    InputTextWidget,
+    InvisibleButtonWidget,
+    LabelTextWidget,
+    SmallButtonWidget,
+    TextColoredWidget,
+    TextDisabledWidget,
+    TextWidget,
+    TextWrappedWidget,
+)
+from champi_imgui.widgets.color import (
+    ColorButtonWidget,
+    ColorEdit3Widget,
+    ColorEdit4Widget,
+    ColorPicker3Widget,
+    ColorPickerWidget,
+)
+from champi_imgui.widgets.input import (
+    CheckboxFlagsWidget,
+    ComboWidget,
+    InputDoubleWidget,
+    InputFloatWidget,
+    InputIntWidget,
+    InputScalarWidget,
+    ListBoxWidget,
+    RadioButtonWidget,
+    SelectableWidget,
+)
+from champi_imgui.widgets.progress import (
+    LoadingIndicatorWidget,
+    ProgressBarWidget,
+    StatusBarWidget,
+)
+
+__all__ = [
+    # Basic widgets
+    "ArrowButtonWidget",
+    "BulletTextWidget",
+    "BulletWidget",
+    "ButtonWidget",
+    # Input widgets
+    "CheckboxFlagsWidget",
+    "CheckboxWidget",
+    # Color widgets
+    "ColorButtonWidget",
+    "ColorEdit3Widget",
+    "ColorEdit4Widget",
+    "ColorPicker3Widget",
+    "ColorPickerWidget",
+    "ComboWidget",
+    "InputDoubleWidget",
+    "InputFloatWidget",
+    "InputIntWidget",
+    "InputScalarWidget",
+    "InputTextWidget",
+    "InvisibleButtonWidget",
+    "LabelTextWidget",
+    "ListBoxWidget",
+    # Progress widgets
+    "LoadingIndicatorWidget",
+    "ProgressBarWidget",
+    "RadioButtonWidget",
+    "SelectableWidget",
+    "SmallButtonWidget",
+    "StatusBarWidget",
+    "TextColoredWidget",
+    "TextDisabledWidget",
+    "TextWidget",
+    "TextWrappedWidget",
+]

--- a/src/champi_imgui/widgets/basic.py
+++ b/src/champi_imgui/widgets/basic.py
@@ -1,0 +1,487 @@
+"""Basic widgets: buttons, text, inputs, checkboxes.
+
+This module contains the fundamental UI widgets for user interaction:
+- Buttons (standard, small, arrow, invisible)
+- Text display (plain, colored, disabled, wrapped, bullet)
+- Text input (single-line, multiline, with hint)
+- Checkboxes
+"""
+
+from imgui_bundle import imgui
+
+from champi_imgui.core.widget import Widget
+
+
+class ButtonWidget(Widget):
+    """Standard button widget.
+
+    A clickable button that triggers callbacks on click.
+    """
+
+    def __init__(self, widget_id: str, label: str = "Button", **props):
+        """Initialize button.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Button label text
+            **props: Additional properties (size, etc.)
+        """
+        props["label"] = label
+        super().__init__(widget_id, **props)
+
+    def render(self) -> bool:
+        """Render the button.
+
+        Returns:
+            True if button was clicked, False otherwise
+        """
+        if not self.state.visible:
+            return False
+
+        label = self.state.properties.get("label", "Button")
+        size = self.state.properties.get("size")
+
+        if size:
+            clicked = imgui.button(label, imgui.ImVec2(size[0], size[1]))
+        else:
+            clicked = imgui.button(label)
+
+        if clicked:
+            self.trigger_callback("on_click")
+
+        return clicked
+
+
+class SmallButtonWidget(Widget):
+    """Small button widget.
+
+    A compact button that takes up less space.
+    """
+
+    def __init__(self, widget_id: str, label: str = "Button", **props):
+        """Initialize small button.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Button label text
+            **props: Additional properties
+        """
+        props["label"] = label
+        super().__init__(widget_id, **props)
+
+    def render(self) -> bool:
+        """Render the small button.
+
+        Returns:
+            True if button was clicked, False otherwise
+        """
+        if not self.state.visible:
+            return False
+
+        label = self.state.properties.get("label", "Button")
+        clicked = imgui.small_button(label)
+
+        if clicked:
+            self.trigger_callback("on_click")
+
+        return clicked
+
+
+class ArrowButtonWidget(Widget):
+    """Arrow button widget.
+
+    A button that displays a directional arrow.
+    """
+
+    def __init__(self, widget_id: str, direction: int = 0, **props):
+        """Initialize arrow button.
+
+        Args:
+            widget_id: Unique widget identifier
+            direction: Arrow direction (imgui.Dir.left/right/up/down)
+            **props: Additional properties
+        """
+        props["direction"] = direction
+        super().__init__(widget_id, **props)
+
+    def render(self) -> bool:
+        """Render the arrow button.
+
+        Returns:
+            True if button was clicked, False otherwise
+        """
+        if not self.state.visible:
+            return False
+
+        direction = self.state.properties.get("direction", 0)
+        clicked = imgui.arrow_button(self.widget_id, direction)
+
+        if clicked:
+            self.trigger_callback("on_click")
+
+        return clicked
+
+
+class InvisibleButtonWidget(Widget):
+    """Invisible button widget.
+
+    A clickable area without visual representation.
+    Useful for custom rendering with click detection.
+    """
+
+    def __init__(
+        self,
+        widget_id: str,
+        size: tuple[float, float] = (100.0, 30.0),
+        **props,
+    ):
+        """Initialize invisible button.
+
+        Args:
+            widget_id: Unique widget identifier
+            size: Button size (width, height)
+            **props: Additional properties
+        """
+        props["size"] = size
+        super().__init__(widget_id, **props)
+
+    def render(self) -> bool:
+        """Render the invisible button.
+
+        Returns:
+            True if button was clicked, False otherwise
+        """
+        if not self.state.visible:
+            return False
+
+        size = self.state.properties.get("size", (100.0, 30.0))
+        flags = self.state.properties.get("flags", 0)
+
+        clicked = imgui.invisible_button(
+            self.widget_id, imgui.ImVec2(size[0], size[1]), flags
+        )
+
+        if clicked:
+            self.trigger_callback("on_click")
+
+        return clicked
+
+
+class TextWidget(Widget):
+    """Static text label widget.
+
+    Displays non-interactive text.
+    """
+
+    def __init__(self, widget_id: str, text: str = "", **props):
+        """Initialize text widget.
+
+        Args:
+            widget_id: Unique widget identifier
+            text: Text to display
+            **props: Additional properties
+        """
+        props["text"] = text
+        super().__init__(widget_id, **props)
+
+    def render(self) -> None:
+        """Render the text."""
+        if not self.state.visible:
+            return
+
+        text = self.state.properties.get("text", "")
+        imgui.text(text)
+
+
+class TextColoredWidget(Widget):
+    """Colored text widget.
+
+    Displays text with a custom color.
+    """
+
+    def __init__(
+        self,
+        widget_id: str,
+        text: str = "",
+        color: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0),
+        **props,
+    ):
+        """Initialize colored text widget.
+
+        Args:
+            widget_id: Unique widget identifier
+            text: Text to display
+            color: RGBA color tuple (0.0-1.0 range)
+            **props: Additional properties
+        """
+        props["text"] = text
+        props["color"] = color
+        super().__init__(widget_id, **props)
+
+    def render(self) -> None:
+        """Render the colored text."""
+        if not self.state.visible:
+            return
+
+        text = self.state.properties.get("text", "")
+        color = self.state.properties.get("color", (1.0, 1.0, 1.0, 1.0))
+        imgui.text_colored(imgui.ImVec4(*color), text)
+
+
+class TextDisabledWidget(Widget):
+    """Disabled text widget.
+
+    Displays text in a disabled (grayed out) style.
+    """
+
+    def __init__(self, widget_id: str, text: str = "", **props):
+        """Initialize disabled text widget.
+
+        Args:
+            widget_id: Unique widget identifier
+            text: Text to display
+            **props: Additional properties
+        """
+        props["text"] = text
+        super().__init__(widget_id, **props)
+
+    def render(self) -> None:
+        """Render the disabled text."""
+        if not self.state.visible:
+            return
+
+        text = self.state.properties.get("text", "")
+        imgui.text_disabled(text)
+
+
+class TextWrappedWidget(Widget):
+    """Wrapped text widget.
+
+    Displays text with automatic line wrapping.
+    """
+
+    def __init__(self, widget_id: str, text: str = "", **props):
+        """Initialize wrapped text widget.
+
+        Args:
+            widget_id: Unique widget identifier
+            text: Text to display
+            **props: Additional properties
+        """
+        props["text"] = text
+        super().__init__(widget_id, **props)
+
+    def render(self) -> None:
+        """Render the wrapped text."""
+        if not self.state.visible:
+            return
+
+        text = self.state.properties.get("text", "")
+        imgui.text_wrapped(text)
+
+
+class BulletTextWidget(Widget):
+    """Bullet text widget.
+
+    Displays text with a bullet point prefix.
+    """
+
+    def __init__(self, widget_id: str, text: str = "", **props):
+        """Initialize bullet text widget.
+
+        Args:
+            widget_id: Unique widget identifier
+            text: Text to display
+            **props: Additional properties
+        """
+        props["text"] = text
+        super().__init__(widget_id, **props)
+
+    def render(self) -> None:
+        """Render the bullet text."""
+        if not self.state.visible:
+            return
+
+        text = self.state.properties.get("text", "")
+        imgui.bullet_text(text)
+
+
+class BulletWidget(Widget):
+    """Bullet point widget.
+
+    Displays a simple bullet point.
+    """
+
+    def __init__(self, widget_id: str, **props):
+        """Initialize bullet widget.
+
+        Args:
+            widget_id: Unique widget identifier
+            **props: Additional properties
+        """
+        super().__init__(widget_id, **props)
+
+    def render(self) -> None:
+        """Render the bullet point."""
+        if not self.state.visible:
+            return
+
+        imgui.bullet()
+
+
+class LabelTextWidget(Widget):
+    """Label text widget.
+
+    Displays a label-value pair (label: value).
+    """
+
+    def __init__(self, widget_id: str, label: str = "Label", text: str = "", **props):
+        """Initialize label text widget.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Label text
+            text: Value text
+            **props: Additional properties
+        """
+        props["label"] = label
+        props["text"] = text
+        super().__init__(widget_id, **props)
+
+    def render(self) -> None:
+        """Render the label-text pair."""
+        if not self.state.visible:
+            return
+
+        label = self.state.properties.get("label", "Label")
+        text = self.state.properties.get("text", "")
+        imgui.label_text(label, text)
+
+
+class InputTextWidget(Widget):
+    """Text input widget.
+
+    Interactive text input field with support for:
+    - Single-line input
+    - Multiline input
+    - Hint text (placeholder)
+    """
+
+    def __init__(self, widget_id: str, label: str = "Input", value: str = "", **props):
+        """Initialize input text widget.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Input label
+            value: Initial value
+            **props: Additional properties (hint, multiline, size)
+        """
+        props["label"] = label
+        props["value"] = value
+        super().__init__(widget_id, **props)
+        self._value = value
+
+    def render(self) -> str:
+        """Render the input field.
+
+        Returns:
+            Current input value
+        """
+        if not self.state.visible:
+            return self._value
+
+        label = self.state.properties.get("label", "Input")
+        hint = self.state.properties.get("hint")
+        multiline = self.state.properties.get("multiline", False)
+        size = self.state.properties.get("size")
+
+        # Choose appropriate ImGui function based on mode
+        if multiline and size:
+            changed, self._value = imgui.input_text_multiline(
+                label, self._value, imgui.ImVec2(size[0], size[1])
+            )
+        elif hint:
+            changed, self._value = imgui.input_text_with_hint(label, hint, self._value)
+        else:
+            changed, self._value = imgui.input_text(label, self._value)
+
+        if changed:
+            self.state.properties["value"] = self._value
+            self.trigger_callback("on_change", self._value)
+
+        return self._value
+
+    def get_value(self) -> str:
+        """Get current input value.
+
+        Returns:
+            Current value
+        """
+        return self._value
+
+    def set_value(self, value: str) -> None:
+        """Set input value.
+
+        Args:
+            value: New value
+        """
+        self._value = value
+        self.state.properties["value"] = value
+
+
+class CheckboxWidget(Widget):
+    """Checkbox widget.
+
+    Interactive checkbox for boolean selection.
+    """
+
+    def __init__(
+        self, widget_id: str, label: str = "Checkbox", checked: bool = False, **props
+    ):
+        """Initialize checkbox.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Checkbox label
+            checked: Initial checked state
+            **props: Additional properties
+        """
+        props["label"] = label
+        props["checked"] = checked
+        super().__init__(widget_id, **props)
+        self._checked = checked
+
+    def render(self) -> bool:
+        """Render the checkbox.
+
+        Returns:
+            Current checked state
+        """
+        if not self.state.visible:
+            return self._checked
+
+        label = self.state.properties.get("label", "Checkbox")
+        changed, self._checked = imgui.checkbox(label, self._checked)
+
+        if changed:
+            self.state.properties["checked"] = self._checked
+            self.trigger_callback("on_change", self._checked)
+
+        return self._checked
+
+    def get_checked(self) -> bool:
+        """Get checked state.
+
+        Returns:
+            True if checked, False otherwise
+        """
+        return self._checked
+
+    def set_checked(self, checked: bool) -> None:
+        """Set checked state.
+
+        Args:
+            checked: New checked state
+        """
+        self._checked = checked
+        self.state.properties["checked"] = checked

--- a/src/champi_imgui/widgets/color.py
+++ b/src/champi_imgui/widgets/color.py
@@ -1,0 +1,333 @@
+"""Color widgets: color pickers, editors, and color buttons.
+
+This module contains widgets for color selection and manipulation:
+- ColorEdit3Widget, ColorEdit4Widget: Direct color value editing
+- ColorPicker3Widget, ColorPickerWidget: Interactive color pickers
+- ColorButtonWidget: Clickable color swatches
+"""
+
+from imgui_bundle import imgui
+
+from champi_imgui.core.widget import Widget
+
+
+class ColorEdit3Widget(Widget):
+    """RGB color editor widget (no alpha channel)."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        label: str = "Color",
+        color: tuple[float, float, float] = (1.0, 1.0, 1.0),
+        **props,
+    ):
+        """Initialize RGB color editor.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Editor label
+            color: Initial RGB color (0.0-1.0 range per channel)
+            **props: Additional properties (flags, etc.)
+        """
+        props["label"] = label
+        props["color"] = color
+        super().__init__(widget_id, **props)
+        self._color = list(color)
+
+    def render(self) -> tuple[float, float, float]:
+        """Render the RGB color editor.
+
+        Returns:
+            Current RGB color tuple
+        """
+        if not self.state.visible:
+            return tuple(self._color)  # type: ignore
+
+        label = self.state.properties.get("label", "Color")
+        flags = self.state.properties.get("flags", 0)
+
+        changed, self._color = imgui.color_edit3(label, self._color, flags)
+
+        if changed:
+            self.state.properties["color"] = tuple(self._color)
+            self.trigger_callback("on_change", tuple(self._color))
+
+        return tuple(self._color)  # type: ignore
+
+    def get_color(self) -> tuple[float, float, float]:
+        """Get current RGB color.
+
+        Returns:
+            RGB color tuple
+        """
+        return tuple(self._color)  # type: ignore
+
+    def set_color(self, color: tuple[float, float, float]) -> None:
+        """Set RGB color.
+
+        Args:
+            color: RGB color tuple
+        """
+        self._color = list(color)
+        self.state.properties["color"] = color
+
+
+class ColorEdit4Widget(Widget):
+    """RGBA color editor widget (with alpha channel)."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        label: str = "Color",
+        color: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0),
+        **props,
+    ):
+        """Initialize RGBA color editor.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Editor label
+            color: Initial RGBA color (0.0-1.0 range per channel)
+            **props: Additional properties (flags, etc.)
+        """
+        props["label"] = label
+        props["color"] = color
+        super().__init__(widget_id, **props)
+        self._color = list(color)
+
+    def render(self) -> tuple[float, float, float, float]:
+        """Render the RGBA color editor.
+
+        Returns:
+            Current RGBA color tuple
+        """
+        if not self.state.visible:
+            return tuple(self._color)  # type: ignore
+
+        label = self.state.properties.get("label", "Color")
+        flags = self.state.properties.get("flags", 0)
+
+        changed, self._color = imgui.color_edit4(label, self._color, flags)
+
+        if changed:
+            self.state.properties["color"] = tuple(self._color)
+            self.trigger_callback("on_change", tuple(self._color))
+
+        return tuple(self._color)  # type: ignore
+
+    def get_color(self) -> tuple[float, float, float, float]:
+        """Get current RGBA color.
+
+        Returns:
+            RGBA color tuple
+        """
+        return tuple(self._color)  # type: ignore
+
+    def set_color(self, color: tuple[float, float, float, float]) -> None:
+        """Set RGBA color.
+
+        Args:
+            color: RGBA color tuple
+        """
+        self._color = list(color)
+        self.state.properties["color"] = color
+
+
+class ColorPicker3Widget(Widget):
+    """RGB color picker widget with interactive picker interface."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        label: str = "Color Picker",
+        color: tuple[float, float, float] = (1.0, 1.0, 1.0),
+        **props,
+    ):
+        """Initialize RGB color picker.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Picker label
+            color: Initial RGB color (0.0-1.0 range per channel)
+            **props: Additional properties (flags, etc.)
+        """
+        props["label"] = label
+        props["color"] = color
+        super().__init__(widget_id, **props)
+        self._color = list(color)
+
+    def render(self) -> tuple[float, float, float]:
+        """Render the RGB color picker.
+
+        Returns:
+            Current RGB color tuple
+        """
+        if not self.state.visible:
+            return tuple(self._color)  # type: ignore
+
+        label = self.state.properties.get("label", "Color Picker")
+        flags = self.state.properties.get("flags", 0)
+
+        changed, self._color = imgui.color_picker3(label, self._color, flags)
+
+        if changed:
+            self.state.properties["color"] = tuple(self._color)
+            self.trigger_callback("on_change", tuple(self._color))
+
+        return tuple(self._color)  # type: ignore
+
+    def get_color(self) -> tuple[float, float, float]:
+        """Get current RGB color.
+
+        Returns:
+            RGB color tuple
+        """
+        return tuple(self._color)  # type: ignore
+
+    def set_color(self, color: tuple[float, float, float]) -> None:
+        """Set RGB color.
+
+        Args:
+            color: RGB color tuple
+        """
+        self._color = list(color)
+        self.state.properties["color"] = color
+
+
+class ColorPickerWidget(Widget):
+    """RGBA color picker widget with interactive picker interface."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        label: str = "Color Picker",
+        color: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0),
+        **props,
+    ):
+        """Initialize RGBA color picker.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Picker label
+            color: Initial RGBA color (0.0-1.0 range per channel)
+            **props: Additional properties (flags, ref_col, etc.)
+        """
+        props["label"] = label
+        props["color"] = color
+        super().__init__(widget_id, **props)
+        self._color = list(color)
+
+    def render(self) -> tuple[float, float, float, float]:
+        """Render the RGBA color picker.
+
+        Returns:
+            Current RGBA color tuple
+        """
+        if not self.state.visible:
+            return tuple(self._color)  # type: ignore
+
+        label = self.state.properties.get("label", "Color Picker")
+        flags = self.state.properties.get("flags", 0)
+        ref_col = self.state.properties.get("ref_col")
+
+        if ref_col:
+            changed, color_result = imgui.color_picker4(
+                label, self._color, flags, ref_col
+            )
+        else:
+            changed, color_result = imgui.color_picker4(label, self._color, flags)
+
+        if changed:
+            # Convert ImVec4 to list
+            self._color = [
+                color_result.x,
+                color_result.y,
+                color_result.z,
+                color_result.w,
+            ]
+            self.state.properties["color"] = tuple(self._color)
+            self.trigger_callback("on_change", tuple(self._color))
+
+        return tuple(self._color)  # type: ignore[return-value]
+
+    def get_color(self) -> tuple[float, float, float, float]:
+        """Get current RGBA color.
+
+        Returns:
+            RGBA color tuple
+        """
+        return tuple(self._color)  # type: ignore
+
+    def set_color(self, color: tuple[float, float, float, float]) -> None:
+        """Set RGBA color.
+
+        Args:
+            color: RGBA color tuple
+        """
+        self._color = list(color)
+        self.state.properties["color"] = color
+
+
+class ColorButtonWidget(Widget):
+    """Color button widget - displays a clickable color swatch."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        color: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0),
+        **props,
+    ):
+        """Initialize color button.
+
+        Args:
+            widget_id: Unique widget identifier (also used as desc_id)
+            color: Button color (RGBA, 0.0-1.0 range per channel)
+            **props: Additional properties (flags, size)
+        """
+        props["color"] = color
+        super().__init__(widget_id, **props)
+        self._color = list(color)
+
+    def render(self) -> bool:
+        """Render the color button.
+
+        Returns:
+            True if button was clicked, False otherwise
+        """
+        if not self.state.visible:
+            return False
+
+        flags = self.state.properties.get("flags", 0)
+        size = self.state.properties.get("size")
+
+        # Create ImVec4 for color
+        color_vec = imgui.ImVec4(*self._color)
+
+        if size:
+            clicked = imgui.color_button(
+                self.widget_id, color_vec, flags, imgui.ImVec2(size[0], size[1])
+            )
+        else:
+            clicked = imgui.color_button(self.widget_id, color_vec, flags)
+
+        if clicked:
+            self.trigger_callback("on_click", tuple(self._color))
+
+        return clicked
+
+    def get_color(self) -> tuple[float, float, float, float]:
+        """Get current button color.
+
+        Returns:
+            RGBA color tuple
+        """
+        return tuple(self._color)  # type: ignore
+
+    def set_color(self, color: tuple[float, float, float, float]) -> None:
+        """Set button color.
+
+        Args:
+            color: RGBA color tuple
+        """
+        self._color = list(color)
+        self.state.properties["color"] = color

--- a/src/champi_imgui/widgets/input.py
+++ b/src/champi_imgui/widgets/input.py
@@ -1,0 +1,550 @@
+"""Input widgets: numeric inputs, combos, lists, and selection controls.
+
+This module contains advanced input widgets:
+- Numeric inputs (int, float, double, scalar)
+- Selection controls (combo, listbox, selectable, radio buttons)
+- Checkbox flags for multi-selection
+"""
+
+from imgui_bundle import imgui
+
+from champi_imgui.core.widget import Widget
+
+
+class InputIntWidget(Widget):
+    """Integer input widget with step controls."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        label: str = "Input Int",
+        value: int = 0,
+        step: int = 1,
+        step_fast: int = 100,
+        **props,
+    ):
+        """Initialize integer input.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Input label
+            value: Initial value
+            step: Step size for +/- buttons
+            step_fast: Fast step size (Ctrl + click)
+            **props: Additional properties
+        """
+        props["label"] = label
+        props["value"] = value
+        props["step"] = step
+        props["step_fast"] = step_fast
+        super().__init__(widget_id, **props)
+        self._value = value
+
+    def render(self) -> int:
+        """Render the integer input.
+
+        Returns:
+            Current integer value
+        """
+        if not self.state.visible:
+            return self._value
+
+        label = self.state.properties.get("label", "Input Int")
+        step = self.state.properties.get("step", 1)
+        step_fast = self.state.properties.get("step_fast", 100)
+
+        changed, self._value = imgui.input_int(label, self._value, step, step_fast)
+
+        if changed:
+            self.state.properties["value"] = self._value
+            self.trigger_callback("on_change", self._value)
+
+        return self._value
+
+    def get_value(self) -> int:
+        """Get current value."""
+        return self._value
+
+    def set_value(self, value: int) -> None:
+        """Set value."""
+        self._value = value
+        self.state.properties["value"] = value
+
+
+class InputFloatWidget(Widget):
+    """Float input widget with step controls."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        label: str = "Input Float",
+        value: float = 0.0,
+        step: float = 0.0,
+        step_fast: float = 0.0,
+        format_str: str = "%.3f",
+        **props,
+    ):
+        """Initialize float input.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Input label
+            value: Initial value
+            step: Step size for +/- buttons (0 = no buttons)
+            step_fast: Fast step size (Ctrl + click)
+            format_str: Display format string
+            **props: Additional properties
+        """
+        props["label"] = label
+        props["value"] = value
+        props["step"] = step
+        props["step_fast"] = step_fast
+        props["format"] = format_str
+        super().__init__(widget_id, **props)
+        self._value = value
+
+    def render(self) -> float:
+        """Render the float input.
+
+        Returns:
+            Current float value
+        """
+        if not self.state.visible:
+            return self._value
+
+        label = self.state.properties.get("label", "Input Float")
+        step = self.state.properties.get("step", 0.0)
+        step_fast = self.state.properties.get("step_fast", 0.0)
+        format_str = self.state.properties.get("format", "%.3f")
+
+        changed, self._value = imgui.input_float(
+            label, self._value, step, step_fast, format_str
+        )
+
+        if changed:
+            self.state.properties["value"] = self._value
+            self.trigger_callback("on_change", self._value)
+
+        return self._value
+
+    def get_value(self) -> float:
+        """Get current value."""
+        return self._value
+
+    def set_value(self, value: float) -> None:
+        """Set value."""
+        self._value = value
+        self.state.properties["value"] = value
+
+
+class InputDoubleWidget(Widget):
+    """Double precision float input widget."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        label: str = "Input Double",
+        value: float = 0.0,
+        step: float = 0.0,
+        step_fast: float = 0.0,
+        format_str: str = "%.6f",
+        **props,
+    ):
+        """Initialize double input.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Input label
+            value: Initial value
+            step: Step size for +/- buttons (0 = no buttons)
+            step_fast: Fast step size (Ctrl + click)
+            format_str: Display format string
+            **props: Additional properties
+        """
+        props["label"] = label
+        props["value"] = value
+        props["step"] = step
+        props["step_fast"] = step_fast
+        props["format"] = format_str
+        super().__init__(widget_id, **props)
+        self._value = value
+
+    def render(self) -> float:
+        """Render the double input.
+
+        Returns:
+            Current double value
+        """
+        if not self.state.visible:
+            return self._value
+
+        label = self.state.properties.get("label", "Input Double")
+        step = self.state.properties.get("step", 0.0)
+        step_fast = self.state.properties.get("step_fast", 0.0)
+        format_str = self.state.properties.get("format", "%.6f")
+
+        changed, self._value = imgui.input_double(
+            label, self._value, step, step_fast, format_str
+        )
+
+        if changed:
+            self.state.properties["value"] = self._value
+            self.trigger_callback("on_change", self._value)
+
+        return self._value
+
+    def get_value(self) -> float:
+        """Get current value."""
+        return self._value
+
+    def set_value(self, value: float) -> None:
+        """Set value."""
+        self._value = value
+        self.state.properties["value"] = value
+
+
+class InputScalarWidget(Widget):
+    """Generic scalar input widget for custom data types."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        label: str = "Input Scalar",
+        value: float = 0.0,
+        data_type: int = imgui.DataType_.float,
+        **props,
+    ):
+        """Initialize scalar input.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Input label
+            value: Initial value
+            data_type: ImGui data type constant
+            **props: Additional properties
+        """
+        props["label"] = label
+        props["value"] = value
+        props["data_type"] = data_type
+        super().__init__(widget_id, **props)
+        self._value = value
+
+    def render(self) -> float:
+        """Render the scalar input.
+
+        Returns:
+            Current scalar value
+        """
+        if not self.state.visible:
+            return self._value
+
+        label = self.state.properties.get("label", "Input Scalar")
+        # Note: imgui.input_scalar has complex API, simplified here
+        # Full implementation would need proper type handling
+        changed, self._value = imgui.input_float(label, self._value)
+
+        if changed:
+            self.state.properties["value"] = self._value
+            self.trigger_callback("on_change", self._value)
+
+        return self._value
+
+    def get_value(self) -> float:
+        """Get current value."""
+        return self._value
+
+
+class RadioButtonWidget(Widget):
+    """Radio button widget for exclusive selection."""
+
+    def __init__(
+        self, widget_id: str, label: str = "Radio", active: bool = False, **props
+    ):
+        """Initialize radio button.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Button label
+            active: Initial active state
+            **props: Additional properties
+        """
+        props["label"] = label
+        props["active"] = active
+        super().__init__(widget_id, **props)
+        self._active = active
+
+    def render(self) -> bool:
+        """Render the radio button.
+
+        Returns:
+            True if clicked, False otherwise
+        """
+        if not self.state.visible:
+            return False
+
+        label = self.state.properties.get("label", "Radio")
+        clicked = imgui.radio_button(label, self._active)
+
+        if clicked:
+            self._active = not self._active
+            self.state.properties["active"] = self._active
+            self.trigger_callback("on_click", self._active)
+
+        return clicked
+
+    def is_active(self) -> bool:
+        """Get active state."""
+        return self._active
+
+    def set_active(self, active: bool) -> None:
+        """Set active state."""
+        self._active = active
+        self.state.properties["active"] = active
+
+
+class ComboWidget(Widget):
+    """Combo box (dropdown) widget."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        label: str = "Combo",
+        items: list[str] | None = None,
+        current_item: int = 0,
+        **props,
+    ):
+        """Initialize combo box.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Combo label
+            items: List of items to display
+            current_item: Initial selected item index
+            **props: Additional properties
+        """
+        props["label"] = label
+        props["items"] = items or []
+        props["current_item"] = current_item
+        super().__init__(widget_id, **props)
+        self._current_item = current_item
+
+    def render(self) -> int:
+        """Render the combo box.
+
+        Returns:
+            Current selected item index
+        """
+        if not self.state.visible:
+            return self._current_item
+
+        label = self.state.properties.get("label", "Combo")
+        items = self.state.properties.get("items", [])
+
+        if not items:
+            return self._current_item
+
+        changed, self._current_item = imgui.combo(label, self._current_item, items)
+
+        if changed:
+            self.state.properties["current_item"] = self._current_item
+            self.trigger_callback(
+                "on_change", self._current_item, items[self._current_item]
+            )
+
+        return self._current_item
+
+    def get_current_item(self) -> int:
+        """Get current selected item index."""
+        return self._current_item
+
+    def get_current_value(self) -> str | None:
+        """Get current selected item value."""
+        items: list[str] = self.state.properties.get("items", [])
+        if 0 <= self._current_item < len(items):
+            return str(items[self._current_item])
+        return None
+
+    def set_items(self, items: list[str]) -> None:
+        """Set the items list."""
+        self.state.properties["items"] = items
+
+
+class ListBoxWidget(Widget):
+    """List box widget for single selection from a list."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        label: str = "ListBox",
+        items: list[str] | None = None,
+        current_item: int = 0,
+        **props,
+    ):
+        """Initialize list box.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: ListBox label
+            items: List of items to display
+            current_item: Initial selected item index
+            **props: Additional properties (height_in_items, etc.)
+        """
+        props["label"] = label
+        props["items"] = items or []
+        props["current_item"] = current_item
+        super().__init__(widget_id, **props)
+        self._current_item = current_item
+
+    def render(self) -> int:
+        """Render the list box.
+
+        Returns:
+            Current selected item index
+        """
+        if not self.state.visible:
+            return self._current_item
+
+        label = self.state.properties.get("label", "ListBox")
+        items = self.state.properties.get("items", [])
+        height_in_items = self.state.properties.get("height_in_items", -1)
+
+        if not items:
+            return self._current_item
+
+        changed, self._current_item = imgui.list_box(
+            label, self._current_item, items, height_in_items
+        )
+
+        if changed:
+            self.state.properties["current_item"] = self._current_item
+            self.trigger_callback(
+                "on_change", self._current_item, items[self._current_item]
+            )
+
+        return self._current_item
+
+    def get_current_item(self) -> int:
+        """Get current selected item index."""
+        return self._current_item
+
+    def get_current_value(self) -> str | None:
+        """Get current selected item value."""
+        items: list[str] = self.state.properties.get("items", [])
+        if 0 <= self._current_item < len(items):
+            return str(items[self._current_item])
+        return None
+
+
+class SelectableWidget(Widget):
+    """Selectable widget for clickable list items."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        label: str = "Selectable",
+        selected: bool = False,
+        **props,
+    ):
+        """Initialize selectable.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Selectable label
+            selected: Initial selected state
+            **props: Additional properties (size, flags)
+        """
+        props["label"] = label
+        props["selected"] = selected
+        super().__init__(widget_id, **props)
+        self._selected = selected
+
+    def render(self) -> bool:
+        """Render the selectable.
+
+        Returns:
+            Current selected state
+        """
+        if not self.state.visible:
+            return self._selected
+
+        label = self.state.properties.get("label", "Selectable")
+        flags = self.state.properties.get("flags", 0)
+        size = self.state.properties.get("size")
+
+        if size:
+            clicked, self._selected = imgui.selectable(
+                label, self._selected, flags, imgui.ImVec2(size[0], size[1])
+            )
+        else:
+            clicked, self._selected = imgui.selectable(label, self._selected, flags)
+
+        if clicked:
+            self.state.properties["selected"] = self._selected
+            self.trigger_callback("on_click", self._selected)
+
+        return self._selected
+
+    def is_selected(self) -> bool:
+        """Get selected state."""
+        return self._selected
+
+    def set_selected(self, selected: bool) -> None:
+        """Set selected state."""
+        self._selected = selected
+        self.state.properties["selected"] = selected
+
+
+class CheckboxFlagsWidget(Widget):
+    """Checkbox flags widget for bitfield manipulation."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        label: str = "Checkbox Flags",
+        flags: int = 0,
+        flags_value: int = 1,
+        **props,
+    ):
+        """Initialize checkbox flags.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Checkbox label
+            flags: Current flags value (bitfield)
+            flags_value: Bit value to toggle
+            **props: Additional properties
+        """
+        props["label"] = label
+        props["flags"] = flags
+        props["flags_value"] = flags_value
+        super().__init__(widget_id, **props)
+        self._flags = flags
+
+    def render(self) -> int:
+        """Render the checkbox flags.
+
+        Returns:
+            Current flags value
+        """
+        if not self.state.visible:
+            return self._flags
+
+        label = self.state.properties.get("label", "Checkbox Flags")
+        flags_value = self.state.properties.get("flags_value", 1)
+
+        changed, self._flags = imgui.checkbox_flags(label, self._flags, flags_value)
+
+        if changed:
+            self.state.properties["flags"] = self._flags
+            self.trigger_callback("on_change", self._flags)
+
+        return self._flags
+
+    def get_flags(self) -> int:
+        """Get current flags value."""
+        return self._flags
+
+    def set_flags(self, flags: int) -> None:
+        """Set flags value."""
+        self._flags = flags
+        self.state.properties["flags"] = flags

--- a/src/champi_imgui/widgets/progress.py
+++ b/src/champi_imgui/widgets/progress.py
@@ -1,0 +1,223 @@
+"""Progress widgets: progress bars, loading indicators, and status displays.
+
+This module contains widgets for showing progress and loading states:
+- ProgressBarWidget: Standard progress bar with fraction/overlay
+- LoadingIndicatorWidget: Animated spinner/loading indicator
+- StatusBarWidget: Status display with text and optional progress
+"""
+
+from imgui_bundle import imgui
+
+from champi_imgui.core.widget import Widget
+
+
+class ProgressBarWidget(Widget):
+    """Progress bar widget for displaying progress as a filled bar."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        fraction: float = 0.0,
+        size: tuple[float, float] = (-1.0, 0.0),
+        overlay: str | None = None,
+        **props,
+    ):
+        """Initialize progress bar.
+
+        Args:
+            widget_id: Unique widget identifier
+            fraction: Progress fraction (0.0 to 1.0)
+            size: Bar size (width, height) - (-1, 0) means full width, default height
+            overlay: Optional text overlay on the progress bar
+            **props: Additional properties
+        """
+        props["fraction"] = fraction
+        props["size"] = size
+        props["overlay"] = overlay
+        super().__init__(widget_id, **props)
+        self._fraction = fraction
+
+    def render(self) -> None:
+        """Render the progress bar."""
+        if not self.state.visible:
+            return
+
+        fraction = self.state.properties.get("fraction", 0.0)
+        size = self.state.properties.get("size", (-1.0, 0.0))
+        overlay = self.state.properties.get("overlay")
+
+        imgui.progress_bar(fraction, imgui.ImVec2(size[0], size[1]), overlay)
+
+    def get_fraction(self) -> float:
+        """Get current progress fraction.
+
+        Returns:
+            Progress fraction (0.0 to 1.0)
+        """
+        return self._fraction
+
+    def set_fraction(self, fraction: float) -> None:
+        """Set progress fraction.
+
+        Args:
+            fraction: Progress fraction (0.0 to 1.0)
+        """
+        self._fraction = max(0.0, min(1.0, fraction))
+        self.state.properties["fraction"] = self._fraction
+
+
+class LoadingIndicatorWidget(Widget):
+    """Loading indicator (spinner) widget for showing loading states."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        label: str = "Loading",
+        radius: float = 10.0,
+        thickness: float = 3.0,
+        color: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0),
+        **props,
+    ):
+        """Initialize loading indicator.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Loading label text
+            radius: Spinner radius in pixels
+            thickness: Spinner line thickness
+            color: Spinner color (RGBA, 0.0-1.0 range per channel)
+            **props: Additional properties
+        """
+        props["label"] = label
+        props["radius"] = radius
+        props["thickness"] = thickness
+        props["color"] = color
+        super().__init__(widget_id, **props)
+
+    def render(self) -> None:
+        """Render the loading indicator."""
+        if not self.state.visible:
+            return
+
+        label = self.state.properties.get("label", "Loading")
+        radius = self.state.properties.get("radius", 10.0)
+        thickness = self.state.properties.get("thickness", 3.0)
+        color = self.state.properties.get("color", (1.0, 1.0, 1.0, 1.0))
+
+        # Custom spinner using draw list
+        draw_list = imgui.get_window_draw_list()
+        pos = imgui.get_cursor_screen_pos()
+        center = imgui.ImVec2(pos.x + radius, pos.y + radius)
+
+        # Simple rotating arc
+        num_segments = 12
+        start = imgui.get_time() * 6.0
+        imgui.dummy(imgui.ImVec2(radius * 2, radius * 2))
+
+        for i in range(num_segments):
+            import math
+
+            angle = start + (i / num_segments) * math.pi * 2
+            alpha = 1.0 - (i / num_segments)
+            col = imgui.get_color_u32(
+                imgui.ImVec4(color[0], color[1], color[2], color[3] * alpha)
+            )
+            draw_list.add_circle_filled(
+                imgui.ImVec2(
+                    center.x + radius * 0.7 * math.cos(angle),
+                    center.y + radius * 0.7 * math.sin(angle),
+                ),
+                thickness,
+                col,
+            )
+
+        # Draw label
+        imgui.same_line()
+        imgui.text(label)
+
+
+class StatusBarWidget(Widget):
+    """Status bar widget for displaying status text with optional progress."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        text: str = "Ready",
+        show_progress: bool = False,
+        progress_fraction: float = 0.0,
+        **props,
+    ):
+        """Initialize status bar.
+
+        Args:
+            widget_id: Unique widget identifier
+            text: Status text to display
+            show_progress: Whether to show progress bar
+            progress_fraction: Progress fraction if show_progress is True (0.0 to 1.0)
+            **props: Additional properties
+        """
+        props["text"] = text
+        props["show_progress"] = show_progress
+        props["progress_fraction"] = progress_fraction
+        super().__init__(widget_id, **props)
+        self._text = text
+        self._progress_fraction = progress_fraction
+
+    def render(self) -> None:
+        """Render the status bar."""
+        if not self.state.visible:
+            return
+
+        text = self.state.properties.get("text", "Ready")
+        show_progress = self.state.properties.get("show_progress", False)
+        progress_fraction = self.state.properties.get("progress_fraction", 0.0)
+
+        # Display status text
+        imgui.text(text)
+
+        # Optionally show progress bar
+        if show_progress:
+            imgui.same_line()
+            imgui.progress_bar(progress_fraction, imgui.ImVec2(100, 0))
+
+    def get_text(self) -> str:
+        """Get current status text.
+
+        Returns:
+            Status text
+        """
+        return self._text
+
+    def set_text(self, text: str) -> None:
+        """Set status text.
+
+        Args:
+            text: New status text
+        """
+        self._text = text
+        self.state.properties["text"] = text
+
+    def get_progress_fraction(self) -> float:
+        """Get current progress fraction.
+
+        Returns:
+            Progress fraction (0.0 to 1.0)
+        """
+        return self._progress_fraction
+
+    def set_progress_fraction(self, fraction: float) -> None:
+        """Set progress fraction.
+
+        Args:
+            fraction: Progress fraction (0.0 to 1.0)
+        """
+        self._progress_fraction = max(0.0, min(1.0, fraction))
+        self.state.properties["progress_fraction"] = self._progress_fraction
+
+    def set_show_progress(self, show: bool) -> None:
+        """Set whether to show progress bar.
+
+        Args:
+            show: True to show progress bar, False to hide
+        """
+        self.state.properties["show_progress"] = show

--- a/tests/test_basic_widgets.py
+++ b/tests/test_basic_widgets.py
@@ -1,0 +1,471 @@
+"""Comprehensive tests for basic widgets.
+
+Tests cover all 13 basic widgets:
+- ButtonWidget, SmallButtonWidget, ArrowButtonWidget, InvisibleButtonWidget
+- TextWidget, TextColoredWidget, TextDisabledWidget, TextWrappedWidget
+- BulletTextWidget, BulletWidget, LabelTextWidget
+- InputTextWidget
+- CheckboxWidget
+"""
+
+from champi_imgui.core.state import WidgetState
+from champi_imgui.widgets.basic import (
+    ArrowButtonWidget,
+    BulletTextWidget,
+    BulletWidget,
+    ButtonWidget,
+    CheckboxWidget,
+    InputTextWidget,
+    InvisibleButtonWidget,
+    LabelTextWidget,
+    SmallButtonWidget,
+    TextColoredWidget,
+    TextDisabledWidget,
+    TextWidget,
+    TextWrappedWidget,
+)
+
+# ==============================================================================
+# ButtonWidget Tests
+# ==============================================================================
+
+
+def test_button_widget_creation():
+    """Test ButtonWidget creation with default values."""
+    widget = ButtonWidget("btn-1")
+
+    assert widget.widget_id == "btn-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_type == "ButtonWidget"
+    assert widget.state.properties["label"] == "Button"
+
+
+def test_button_widget_with_label():
+    """Test ButtonWidget with custom label."""
+    widget = ButtonWidget("btn-2", label="Click Me")
+
+    assert widget.state.properties["label"] == "Click Me"
+
+
+def test_button_widget_with_size():
+    """Test ButtonWidget with custom size."""
+    widget = ButtonWidget("btn-3", label="Button", size=(150.0, 40.0))
+
+    assert widget.state.properties["size"] == (150.0, 40.0)
+
+
+def test_button_widget_visibility():
+    """Test ButtonWidget visibility handling."""
+    widget = ButtonWidget("btn-4")
+
+    # Default visible
+    assert widget.state.visible is True
+
+    # Set invisible
+    widget.set_visible(False)
+    assert widget.state.visible is False
+
+
+def test_button_widget_serialization():
+    """Test ButtonWidget serialization."""
+    widget = ButtonWidget("btn-5", label="Serialize", size=(100.0, 30.0))
+
+    data = widget.serialize()
+
+    assert data["widget_id"] == "btn-5"
+    assert data["widget_type"] == "ButtonWidget"
+    assert data["properties"]["label"] == "Serialize"
+    assert data["properties"]["size"] == (100.0, 30.0)
+
+
+# ==============================================================================
+# SmallButtonWidget Tests
+# ==============================================================================
+
+
+def test_small_button_widget_creation():
+    """Test SmallButtonWidget creation."""
+    widget = SmallButtonWidget("small-btn-1")
+
+    assert widget.widget_id == "small-btn-1"
+    assert widget.state.widget_type == "SmallButtonWidget"
+    assert widget.state.properties["label"] == "Button"
+
+
+def test_small_button_widget_custom_label():
+    """Test SmallButtonWidget with custom label."""
+    widget = SmallButtonWidget("small-btn-2", label="Small")
+
+    assert widget.state.properties["label"] == "Small"
+
+
+# ==============================================================================
+# ArrowButtonWidget Tests
+# ==============================================================================
+
+
+def test_arrow_button_widget_creation():
+    """Test ArrowButtonWidget creation."""
+    widget = ArrowButtonWidget("arrow-1")
+
+    assert widget.widget_id == "arrow-1"
+    assert widget.state.widget_type == "ArrowButtonWidget"
+    assert widget.state.properties["direction"] == 0
+
+
+def test_arrow_button_widget_with_direction():
+    """Test ArrowButtonWidget with custom direction."""
+    widget = ArrowButtonWidget("arrow-2", direction=1)
+
+    assert widget.state.properties["direction"] == 1
+
+
+# ==============================================================================
+# InvisibleButtonWidget Tests
+# ==============================================================================
+
+
+def test_invisible_button_widget_creation():
+    """Test InvisibleButtonWidget creation."""
+    widget = InvisibleButtonWidget("invisible-1")
+
+    assert widget.widget_id == "invisible-1"
+    assert widget.state.widget_type == "InvisibleButtonWidget"
+    assert widget.state.properties["size"] == (100.0, 30.0)
+
+
+def test_invisible_button_widget_custom_size():
+    """Test InvisibleButtonWidget with custom size."""
+    widget = InvisibleButtonWidget("invisible-2", size=(200.0, 50.0))
+
+    assert widget.state.properties["size"] == (200.0, 50.0)
+
+
+def test_invisible_button_widget_with_flags():
+    """Test InvisibleButtonWidget with flags."""
+    widget = InvisibleButtonWidget("invisible-3", flags=1)
+
+    assert widget.state.properties["flags"] == 1
+
+
+# ==============================================================================
+# TextWidget Tests
+# ==============================================================================
+
+
+def test_text_widget_creation():
+    """Test TextWidget creation."""
+    widget = TextWidget("text-1")
+
+    assert widget.widget_id == "text-1"
+    assert widget.state.widget_type == "TextWidget"
+    assert widget.state.properties["text"] == ""
+
+
+def test_text_widget_with_text():
+    """Test TextWidget with text."""
+    widget = TextWidget("text-2", text="Hello World")
+
+    assert widget.state.properties["text"] == "Hello World"
+
+
+def test_text_widget_update_text():
+    """Test TextWidget text update."""
+    widget = TextWidget("text-3", text="Initial")
+
+    widget.update(text="Updated")
+    assert widget.state.properties["text"] == "Updated"
+
+
+# ==============================================================================
+# TextColoredWidget Tests
+# ==============================================================================
+
+
+def test_text_colored_widget_creation():
+    """Test TextColoredWidget creation."""
+    widget = TextColoredWidget("colored-1")
+
+    assert widget.widget_id == "colored-1"
+    assert widget.state.widget_type == "TextColoredWidget"
+    assert widget.state.properties["text"] == ""
+    assert widget.state.properties["color"] == (1.0, 1.0, 1.0, 1.0)
+
+
+def test_text_colored_widget_with_color():
+    """Test TextColoredWidget with custom color."""
+    widget = TextColoredWidget("colored-2", text="Red Text", color=(1.0, 0.0, 0.0, 1.0))
+
+    assert widget.state.properties["text"] == "Red Text"
+    assert widget.state.properties["color"] == (1.0, 0.0, 0.0, 1.0)
+
+
+# ==============================================================================
+# TextDisabledWidget Tests
+# ==============================================================================
+
+
+def test_text_disabled_widget_creation():
+    """Test TextDisabledWidget creation."""
+    widget = TextDisabledWidget("disabled-1")
+
+    assert widget.widget_id == "disabled-1"
+    assert widget.state.widget_type == "TextDisabledWidget"
+    assert widget.state.properties["text"] == ""
+
+
+def test_text_disabled_widget_with_text():
+    """Test TextDisabledWidget with text."""
+    widget = TextDisabledWidget("disabled-2", text="Disabled")
+
+    assert widget.state.properties["text"] == "Disabled"
+
+
+# ==============================================================================
+# TextWrappedWidget Tests
+# ==============================================================================
+
+
+def test_text_wrapped_widget_creation():
+    """Test TextWrappedWidget creation."""
+    widget = TextWrappedWidget("wrapped-1")
+
+    assert widget.widget_id == "wrapped-1"
+    assert widget.state.widget_type == "TextWrappedWidget"
+    assert widget.state.properties["text"] == ""
+
+
+def test_text_wrapped_widget_with_text():
+    """Test TextWrappedWidget with long text."""
+    long_text = "This is a very long text that should wrap to multiple lines."
+    widget = TextWrappedWidget("wrapped-2", text=long_text)
+
+    assert widget.state.properties["text"] == long_text
+
+
+# ==============================================================================
+# BulletTextWidget Tests
+# ==============================================================================
+
+
+def test_bullet_text_widget_creation():
+    """Test BulletTextWidget creation."""
+    widget = BulletTextWidget("bullet-text-1")
+
+    assert widget.widget_id == "bullet-text-1"
+    assert widget.state.widget_type == "BulletTextWidget"
+    assert widget.state.properties["text"] == ""
+
+
+def test_bullet_text_widget_with_text():
+    """Test BulletTextWidget with text."""
+    widget = BulletTextWidget("bullet-text-2", text="Bullet point")
+
+    assert widget.state.properties["text"] == "Bullet point"
+
+
+# ==============================================================================
+# BulletWidget Tests
+# ==============================================================================
+
+
+def test_bullet_widget_creation():
+    """Test BulletWidget creation."""
+    widget = BulletWidget("bullet-1")
+
+    assert widget.widget_id == "bullet-1"
+    assert widget.state.widget_type == "BulletWidget"
+
+
+def test_bullet_widget_serialization():
+    """Test BulletWidget serialization."""
+    widget = BulletWidget("bullet-2")
+
+    data = widget.serialize()
+    assert data["widget_id"] == "bullet-2"
+    assert data["widget_type"] == "BulletWidget"
+
+
+# ==============================================================================
+# LabelTextWidget Tests
+# ==============================================================================
+
+
+def test_label_text_widget_creation():
+    """Test LabelTextWidget creation."""
+    widget = LabelTextWidget("label-1")
+
+    assert widget.widget_id == "label-1"
+    assert widget.state.widget_type == "LabelTextWidget"
+    assert widget.state.properties["label"] == "Label"
+    assert widget.state.properties["text"] == ""
+
+
+def test_label_text_widget_with_values():
+    """Test LabelTextWidget with label and text."""
+    widget = LabelTextWidget("label-2", label="Name", text="John Doe")
+
+    assert widget.state.properties["label"] == "Name"
+    assert widget.state.properties["text"] == "John Doe"
+
+
+# ==============================================================================
+# InputTextWidget Tests
+# ==============================================================================
+
+
+def test_input_text_widget_creation():
+    """Test InputTextWidget creation."""
+    widget = InputTextWidget("input-1")
+
+    assert widget.widget_id == "input-1"
+    assert widget.state.widget_type == "InputTextWidget"
+    assert widget.state.properties["label"] == "Input"
+    assert widget.state.properties["value"] == ""
+    assert widget._value == ""
+
+
+def test_input_text_widget_with_value():
+    """Test InputTextWidget with initial value."""
+    widget = InputTextWidget("input-2", label="Name", value="Initial")
+
+    assert widget.state.properties["label"] == "Name"
+    assert widget.state.properties["value"] == "Initial"
+    assert widget._value == "Initial"
+
+
+def test_input_text_widget_get_value():
+    """Test InputTextWidget get_value method."""
+    widget = InputTextWidget("input-3", value="Test")
+
+    assert widget.get_value() == "Test"
+
+
+def test_input_text_widget_set_value():
+    """Test InputTextWidget set_value method."""
+    widget = InputTextWidget("input-4", value="Initial")
+
+    widget.set_value("Updated")
+    assert widget.get_value() == "Updated"
+    assert widget.state.properties["value"] == "Updated"
+
+
+def test_input_text_widget_with_hint():
+    """Test InputTextWidget with hint."""
+    widget = InputTextWidget("input-5", label="Email", hint="user@example.com")
+
+    assert widget.state.properties["hint"] == "user@example.com"
+
+
+def test_input_text_widget_multiline():
+    """Test InputTextWidget in multiline mode."""
+    widget = InputTextWidget(
+        "input-6", label="Description", multiline=True, size=(300.0, 100.0)
+    )
+
+    assert widget.state.properties["multiline"] is True
+    assert widget.state.properties["size"] == (300.0, 100.0)
+
+
+# ==============================================================================
+# CheckboxWidget Tests
+# ==============================================================================
+
+
+def test_checkbox_widget_creation():
+    """Test CheckboxWidget creation."""
+    widget = CheckboxWidget("check-1")
+
+    assert widget.widget_id == "check-1"
+    assert widget.state.widget_type == "CheckboxWidget"
+    assert widget.state.properties["label"] == "Checkbox"
+    assert widget.state.properties["checked"] is False
+    assert widget._checked is False
+
+
+def test_checkbox_widget_with_checked():
+    """Test CheckboxWidget with initial checked state."""
+    widget = CheckboxWidget("check-2", label="Accept", checked=True)
+
+    assert widget.state.properties["label"] == "Accept"
+    assert widget.state.properties["checked"] is True
+    assert widget._checked is True
+
+
+def test_checkbox_widget_get_checked():
+    """Test CheckboxWidget get_checked method."""
+    widget = CheckboxWidget("check-3", checked=True)
+
+    assert widget.get_checked() is True
+
+
+def test_checkbox_widget_set_checked():
+    """Test CheckboxWidget set_checked method."""
+    widget = CheckboxWidget("check-4", checked=False)
+
+    widget.set_checked(True)
+    assert widget.get_checked() is True
+    assert widget.state.properties["checked"] is True
+
+    widget.set_checked(False)
+    assert widget.get_checked() is False
+    assert widget.state.properties["checked"] is False
+
+
+# ==============================================================================
+# Edge Cases and Coverage
+# ==============================================================================
+
+
+def test_widget_visibility_affects_render():
+    """Test that invisible widgets respect visibility flag."""
+    button = ButtonWidget("vis-test-1")
+    text = TextWidget("vis-test-2", text="Hidden")
+    checkbox = CheckboxWidget("vis-test-3")
+
+    # All widgets start visible
+    assert button.state.visible is True
+    assert text.state.visible is True
+    assert checkbox.state.visible is True
+
+    # Set invisible
+    button.set_visible(False)
+    text.set_visible(False)
+    checkbox.set_visible(False)
+
+    assert button.state.visible is False
+    assert text.state.visible is False
+    assert checkbox.state.visible is False
+
+
+def test_widget_property_updates():
+    """Test that widget property updates work correctly."""
+    button = ButtonWidget("update-1", label="Initial")
+
+    button.update(label="Updated", color="blue")
+    assert button.state.properties["label"] == "Updated"
+    assert button.state.properties["color"] == "blue"
+
+
+def test_all_widgets_have_state():
+    """Test that all widgets have proper state."""
+    widgets = [
+        ButtonWidget("w1"),
+        SmallButtonWidget("w2"),
+        ArrowButtonWidget("w3"),
+        InvisibleButtonWidget("w4"),
+        TextWidget("w5"),
+        TextColoredWidget("w6"),
+        TextDisabledWidget("w7"),
+        TextWrappedWidget("w8"),
+        BulletTextWidget("w9"),
+        BulletWidget("w10"),
+        LabelTextWidget("w11"),
+        InputTextWidget("w12"),
+        CheckboxWidget("w13"),
+    ]
+
+    for widget in widgets:
+        assert isinstance(widget.state, WidgetState)
+        assert widget.state.widget_id is not None
+        assert widget.state.widget_type is not None

--- a/tests/test_basic_widgets_render.py
+++ b/tests/test_basic_widgets_render.py
@@ -1,0 +1,425 @@
+"""Render tests for basic widgets using mocks.
+
+These tests verify render() method behavior by mocking imgui calls.
+They ensure render methods handle visibility, call correct ImGui functions,
+and trigger callbacks appropriately.
+"""
+
+from unittest.mock import patch
+
+from champi_imgui.widgets.basic import (
+    ArrowButtonWidget,
+    BulletTextWidget,
+    BulletWidget,
+    ButtonWidget,
+    CheckboxWidget,
+    InputTextWidget,
+    InvisibleButtonWidget,
+    LabelTextWidget,
+    SmallButtonWidget,
+    TextColoredWidget,
+    TextDisabledWidget,
+    TextWidget,
+    TextWrappedWidget,
+)
+
+# ==============================================================================
+# Button Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_button_widget_render(mock_imgui):
+    """Test ButtonWidget render method."""
+    mock_imgui.button.return_value = True
+    widget = ButtonWidget("btn-1", label="Click")
+
+    result = widget.render()
+
+    assert result is True
+    mock_imgui.button.assert_called_once()
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_button_widget_render_with_size(mock_imgui):
+    """Test ButtonWidget render with size."""
+    mock_imgui.button.return_value = False
+    widget = ButtonWidget("btn-2", label="Button", size=(100.0, 50.0))
+
+    result = widget.render()
+
+    assert result is False
+    mock_imgui.button.assert_called_once()
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_button_widget_render_invisible(mock_imgui):
+    """Test ButtonWidget render when invisible."""
+    widget = ButtonWidget("btn-3")
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result is False
+    mock_imgui.button.assert_not_called()
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_button_widget_callback_on_click(mock_imgui):
+    """Test ButtonWidget triggers callback on click."""
+    mock_imgui.button.return_value = True
+    widget = ButtonWidget("btn-4")
+
+    callback_triggered = []
+
+    def on_click():
+        callback_triggered.append(True)
+
+    widget.register_callback("on_click", on_click)
+    widget.render()
+
+    assert len(callback_triggered) == 1
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_small_button_widget_render(mock_imgui):
+    """Test SmallButtonWidget render method."""
+    mock_imgui.small_button.return_value = True
+    widget = SmallButtonWidget("small-1", label="Small")
+
+    result = widget.render()
+
+    assert result is True
+    mock_imgui.small_button.assert_called_once_with("Small")
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_small_button_widget_render_invisible(mock_imgui):
+    """Test SmallButtonWidget render when invisible."""
+    widget = SmallButtonWidget("small-2")
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result is False
+    mock_imgui.small_button.assert_not_called()
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_arrow_button_widget_render(mock_imgui):
+    """Test ArrowButtonWidget render method."""
+    mock_imgui.arrow_button.return_value = True
+    widget = ArrowButtonWidget("arrow-1", direction=1)
+
+    result = widget.render()
+
+    assert result is True
+    mock_imgui.arrow_button.assert_called_once_with("arrow-1", 1)
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_arrow_button_widget_render_invisible(mock_imgui):
+    """Test ArrowButtonWidget render when invisible."""
+    widget = ArrowButtonWidget("arrow-2")
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result is False
+    mock_imgui.arrow_button.assert_not_called()
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_invisible_button_widget_render(mock_imgui):
+    """Test InvisibleButtonWidget render method."""
+    mock_imgui.invisible_button.return_value = True
+    widget = InvisibleButtonWidget("inv-1", size=(200.0, 100.0))
+
+    result = widget.render()
+
+    assert result is True
+    mock_imgui.invisible_button.assert_called_once()
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_invisible_button_widget_render_invisible(mock_imgui):
+    """Test InvisibleButtonWidget render when invisible."""
+    widget = InvisibleButtonWidget("inv-2")
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result is False
+    mock_imgui.invisible_button.assert_not_called()
+
+
+# ==============================================================================
+# Text Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_text_widget_render(mock_imgui):
+    """Test TextWidget render method."""
+    widget = TextWidget("text-1", text="Hello")
+
+    widget.render()
+
+    mock_imgui.text.assert_called_once_with("Hello")
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_text_widget_render_invisible(mock_imgui):
+    """Test TextWidget render when invisible."""
+    widget = TextWidget("text-2", text="Hidden")
+    widget.set_visible(False)
+
+    widget.render()
+
+    mock_imgui.text.assert_not_called()
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_text_colored_widget_render(mock_imgui):
+    """Test TextColoredWidget render method."""
+    widget = TextColoredWidget("colored-1", text="Red", color=(1.0, 0.0, 0.0, 1.0))
+
+    widget.render()
+
+    mock_imgui.text_colored.assert_called_once()
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_text_colored_widget_render_invisible(mock_imgui):
+    """Test TextColoredWidget render when invisible."""
+    widget = TextColoredWidget("colored-2")
+    widget.set_visible(False)
+
+    widget.render()
+
+    mock_imgui.text_colored.assert_not_called()
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_text_disabled_widget_render(mock_imgui):
+    """Test TextDisabledWidget render method."""
+    widget = TextDisabledWidget("disabled-1", text="Disabled")
+
+    widget.render()
+
+    mock_imgui.text_disabled.assert_called_once_with("Disabled")
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_text_disabled_widget_render_invisible(mock_imgui):
+    """Test TextDisabledWidget render when invisible."""
+    widget = TextDisabledWidget("disabled-2")
+    widget.set_visible(False)
+
+    widget.render()
+
+    mock_imgui.text_disabled.assert_not_called()
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_text_wrapped_widget_render(mock_imgui):
+    """Test TextWrappedWidget render method."""
+    widget = TextWrappedWidget("wrapped-1", text="Long text")
+
+    widget.render()
+
+    mock_imgui.text_wrapped.assert_called_once_with("Long text")
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_text_wrapped_widget_render_invisible(mock_imgui):
+    """Test TextWrappedWidget render when invisible."""
+    widget = TextWrappedWidget("wrapped-2")
+    widget.set_visible(False)
+
+    widget.render()
+
+    mock_imgui.text_wrapped.assert_not_called()
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_bullet_text_widget_render(mock_imgui):
+    """Test BulletTextWidget render method."""
+    widget = BulletTextWidget("bullet-text-1", text="Bullet")
+
+    widget.render()
+
+    mock_imgui.bullet_text.assert_called_once_with("Bullet")
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_bullet_text_widget_render_invisible(mock_imgui):
+    """Test BulletTextWidget render when invisible."""
+    widget = BulletTextWidget("bullet-text-2")
+    widget.set_visible(False)
+
+    widget.render()
+
+    mock_imgui.bullet_text.assert_not_called()
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_bullet_widget_render(mock_imgui):
+    """Test BulletWidget render method."""
+    widget = BulletWidget("bullet-1")
+
+    widget.render()
+
+    mock_imgui.bullet.assert_called_once()
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_bullet_widget_render_invisible(mock_imgui):
+    """Test BulletWidget render when invisible."""
+    widget = BulletWidget("bullet-2")
+    widget.set_visible(False)
+
+    widget.render()
+
+    mock_imgui.bullet.assert_not_called()
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_label_text_widget_render(mock_imgui):
+    """Test LabelTextWidget render method."""
+    widget = LabelTextWidget("label-1", label="Name", text="John")
+
+    widget.render()
+
+    mock_imgui.label_text.assert_called_once_with("Name", "John")
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_label_text_widget_render_invisible(mock_imgui):
+    """Test LabelTextWidget render when invisible."""
+    widget = LabelTextWidget("label-2")
+    widget.set_visible(False)
+
+    widget.render()
+
+    mock_imgui.label_text.assert_not_called()
+
+
+# ==============================================================================
+# InputTextWidget Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_input_text_widget_render(mock_imgui):
+    """Test InputTextWidget render method."""
+    mock_imgui.input_text.return_value = (False, "test")
+    widget = InputTextWidget("input-1", label="Name", value="test")
+
+    result = widget.render()
+
+    assert result == "test"
+    mock_imgui.input_text.assert_called_once()
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_input_text_widget_render_invisible(mock_imgui):
+    """Test InputTextWidget render when invisible."""
+    widget = InputTextWidget("input-2", value="hidden")
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result == "hidden"
+    mock_imgui.input_text.assert_not_called()
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_input_text_widget_render_with_hint(mock_imgui):
+    """Test InputTextWidget render with hint."""
+    mock_imgui.input_text_with_hint.return_value = (False, "")
+    widget = InputTextWidget("input-3", label="Email", hint="user@example.com")
+
+    widget.render()
+
+    mock_imgui.input_text_with_hint.assert_called_once()
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_input_text_widget_render_multiline(mock_imgui):
+    """Test InputTextWidget render in multiline mode."""
+    mock_imgui.input_text_multiline.return_value = (False, "")
+    widget = InputTextWidget(
+        "input-4", label="Description", multiline=True, size=(300.0, 100.0)
+    )
+
+    widget.render()
+
+    mock_imgui.input_text_multiline.assert_called_once()
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_input_text_widget_value_changed(mock_imgui):
+    """Test InputTextWidget triggers callback on value change."""
+    mock_imgui.input_text.return_value = (True, "new value")
+    widget = InputTextWidget("input-5", value="old")
+
+    callback_values = []
+
+    def on_change(value):
+        callback_values.append(value)
+
+    widget.register_callback("on_change", on_change)
+    result = widget.render()
+
+    assert result == "new value"
+    assert widget.state.properties["value"] == "new value"
+    assert callback_values == ["new value"]
+
+
+# ==============================================================================
+# CheckboxWidget Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_checkbox_widget_render(mock_imgui):
+    """Test CheckboxWidget render method."""
+    mock_imgui.checkbox.return_value = (False, False)
+    widget = CheckboxWidget("check-1", label="Accept")
+
+    result = widget.render()
+
+    assert result is False
+    mock_imgui.checkbox.assert_called_once_with("Accept", False)
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_checkbox_widget_render_invisible(mock_imgui):
+    """Test CheckboxWidget render when invisible."""
+    widget = CheckboxWidget("check-2", checked=True)
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result is True
+    mock_imgui.checkbox.assert_not_called()
+
+
+@patch("champi_imgui.widgets.basic.imgui")
+def test_checkbox_widget_changed(mock_imgui):
+    """Test CheckboxWidget triggers callback on state change."""
+    mock_imgui.checkbox.return_value = (True, True)
+    widget = CheckboxWidget("check-3", label="Agree", checked=False)
+
+    callback_states = []
+
+    def on_change(checked):
+        callback_states.append(checked)
+
+    widget.register_callback("on_change", on_change)
+    result = widget.render()
+
+    assert result is True
+    assert widget.state.properties["checked"] is True
+    assert callback_states == [True]

--- a/tests/test_color_widgets.py
+++ b/tests/test_color_widgets.py
@@ -1,0 +1,287 @@
+"""Comprehensive tests for color widgets.
+
+Tests cover all 5 color widgets:
+- ColorEdit3Widget, ColorEdit4Widget
+- ColorPicker3Widget, ColorPickerWidget
+- ColorButtonWidget
+"""
+
+from champi_imgui.core.state import WidgetState
+from champi_imgui.widgets.color import (
+    ColorButtonWidget,
+    ColorEdit3Widget,
+    ColorEdit4Widget,
+    ColorPicker3Widget,
+    ColorPickerWidget,
+)
+
+# ==============================================================================
+# ColorEdit3Widget Tests
+# ==============================================================================
+
+
+def test_color_edit3_widget_creation():
+    """Test ColorEdit3Widget creation with default values."""
+    widget = ColorEdit3Widget("color3-1")
+
+    assert widget.widget_id == "color3-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_type == "ColorEdit3Widget"
+    assert widget.state.properties["label"] == "Color"
+    assert widget.state.properties["color"] == (1.0, 1.0, 1.0)
+    assert widget._color == [1.0, 1.0, 1.0]
+
+
+def test_color_edit3_widget_with_color():
+    """Test ColorEdit3Widget with custom color."""
+    widget = ColorEdit3Widget("color3-2", label="RGB", color=(0.5, 0.25, 0.75), flags=1)
+
+    assert widget.state.properties["label"] == "RGB"
+    assert widget.state.properties["color"] == (0.5, 0.25, 0.75)
+    assert widget.state.properties["flags"] == 1
+    assert widget._color == [0.5, 0.25, 0.75]
+
+
+def test_color_edit3_widget_get_color():
+    """Test ColorEdit3Widget get_color method."""
+    widget = ColorEdit3Widget("color3-3", color=(0.1, 0.2, 0.3))
+
+    assert widget.get_color() == (0.1, 0.2, 0.3)
+
+
+def test_color_edit3_widget_set_color():
+    """Test ColorEdit3Widget set_color method."""
+    widget = ColorEdit3Widget("color3-4")
+
+    widget.set_color((0.9, 0.8, 0.7))
+    assert widget.get_color() == (0.9, 0.8, 0.7)
+    assert widget.state.properties["color"] == (0.9, 0.8, 0.7)
+
+
+# ==============================================================================
+# ColorEdit4Widget Tests
+# ==============================================================================
+
+
+def test_color_edit4_widget_creation():
+    """Test ColorEdit4Widget creation with default values."""
+    widget = ColorEdit4Widget("color4-1")
+
+    assert widget.widget_id == "color4-1"
+    assert widget.state.widget_type == "ColorEdit4Widget"
+    assert widget.state.properties["label"] == "Color"
+    assert widget.state.properties["color"] == (1.0, 1.0, 1.0, 1.0)
+    assert widget._color == [1.0, 1.0, 1.0, 1.0]
+
+
+def test_color_edit4_widget_with_color():
+    """Test ColorEdit4Widget with custom color."""
+    widget = ColorEdit4Widget(
+        "color4-2", label="RGBA", color=(0.5, 0.25, 0.75, 0.5), flags=2
+    )
+
+    assert widget.state.properties["label"] == "RGBA"
+    assert widget.state.properties["color"] == (0.5, 0.25, 0.75, 0.5)
+    assert widget.state.properties["flags"] == 2
+    assert widget._color == [0.5, 0.25, 0.75, 0.5]
+
+
+def test_color_edit4_widget_get_color():
+    """Test ColorEdit4Widget get_color method."""
+    widget = ColorEdit4Widget("color4-3", color=(0.1, 0.2, 0.3, 0.4))
+
+    assert widget.get_color() == (0.1, 0.2, 0.3, 0.4)
+
+
+def test_color_edit4_widget_set_color():
+    """Test ColorEdit4Widget set_color method."""
+    widget = ColorEdit4Widget("color4-4")
+
+    widget.set_color((0.9, 0.8, 0.7, 0.6))
+    assert widget.get_color() == (0.9, 0.8, 0.7, 0.6)
+    assert widget.state.properties["color"] == (0.9, 0.8, 0.7, 0.6)
+
+
+# ==============================================================================
+# ColorPicker3Widget Tests
+# ==============================================================================
+
+
+def test_color_picker3_widget_creation():
+    """Test ColorPicker3Widget creation."""
+    widget = ColorPicker3Widget("picker3-1")
+
+    assert widget.widget_id == "picker3-1"
+    assert widget.state.widget_type == "ColorPicker3Widget"
+    assert widget.state.properties["label"] == "Color Picker"
+    assert widget.state.properties["color"] == (1.0, 1.0, 1.0)
+    assert widget._color == [1.0, 1.0, 1.0]
+
+
+def test_color_picker3_widget_with_color():
+    """Test ColorPicker3Widget with custom color."""
+    widget = ColorPicker3Widget(
+        "picker3-2", label="Pick RGB", color=(0.2, 0.4, 0.6), flags=4
+    )
+
+    assert widget.state.properties["label"] == "Pick RGB"
+    assert widget.state.properties["color"] == (0.2, 0.4, 0.6)
+    assert widget.state.properties["flags"] == 4
+
+
+def test_color_picker3_widget_get_color():
+    """Test ColorPicker3Widget get_color method."""
+    widget = ColorPicker3Widget("picker3-3", color=(0.3, 0.3, 0.3))
+
+    assert widget.get_color() == (0.3, 0.3, 0.3)
+
+
+def test_color_picker3_widget_set_color():
+    """Test ColorPicker3Widget set_color method."""
+    widget = ColorPicker3Widget("picker3-4")
+
+    widget.set_color((0.5, 0.5, 0.5))
+    assert widget.get_color() == (0.5, 0.5, 0.5)
+    assert widget.state.properties["color"] == (0.5, 0.5, 0.5)
+
+
+# ==============================================================================
+# ColorPickerWidget Tests
+# ==============================================================================
+
+
+def test_color_picker_widget_creation():
+    """Test ColorPickerWidget creation."""
+    widget = ColorPickerWidget("picker4-1")
+
+    assert widget.widget_id == "picker4-1"
+    assert widget.state.widget_type == "ColorPickerWidget"
+    assert widget.state.properties["label"] == "Color Picker"
+    assert widget.state.properties["color"] == (1.0, 1.0, 1.0, 1.0)
+    assert widget._color == [1.0, 1.0, 1.0, 1.0]
+
+
+def test_color_picker_widget_with_color():
+    """Test ColorPickerWidget with custom color."""
+    widget = ColorPickerWidget(
+        "picker4-2", label="Pick RGBA", color=(0.2, 0.4, 0.6, 0.8), flags=8
+    )
+
+    assert widget.state.properties["label"] == "Pick RGBA"
+    assert widget.state.properties["color"] == (0.2, 0.4, 0.6, 0.8)
+    assert widget.state.properties["flags"] == 8
+
+
+def test_color_picker_widget_with_ref_col():
+    """Test ColorPickerWidget with reference color."""
+    widget = ColorPickerWidget(
+        "picker4-3", color=(0.5, 0.5, 0.5, 1.0), ref_col=[0.0, 0.0, 0.0, 1.0]
+    )
+
+    assert widget.state.properties["ref_col"] == [0.0, 0.0, 0.0, 1.0]
+
+
+def test_color_picker_widget_get_color():
+    """Test ColorPickerWidget get_color method."""
+    widget = ColorPickerWidget("picker4-4", color=(0.3, 0.3, 0.3, 0.3))
+
+    assert widget.get_color() == (0.3, 0.3, 0.3, 0.3)
+
+
+def test_color_picker_widget_set_color():
+    """Test ColorPickerWidget set_color method."""
+    widget = ColorPickerWidget("picker4-5")
+
+    widget.set_color((0.5, 0.5, 0.5, 0.5))
+    assert widget.get_color() == (0.5, 0.5, 0.5, 0.5)
+    assert widget.state.properties["color"] == (0.5, 0.5, 0.5, 0.5)
+
+
+# ==============================================================================
+# ColorButtonWidget Tests
+# ==============================================================================
+
+
+def test_color_button_widget_creation():
+    """Test ColorButtonWidget creation."""
+    widget = ColorButtonWidget("btn-color-1")
+
+    assert widget.widget_id == "btn-color-1"
+    assert widget.state.widget_type == "ColorButtonWidget"
+    assert widget.state.properties["color"] == (1.0, 1.0, 1.0, 1.0)
+    assert widget._color == [1.0, 1.0, 1.0, 1.0]
+
+
+def test_color_button_widget_with_color():
+    """Test ColorButtonWidget with custom color."""
+    widget = ColorButtonWidget("btn-color-2", color=(0.8, 0.2, 0.2, 1.0), flags=16)
+
+    assert widget.state.properties["color"] == (0.8, 0.2, 0.2, 1.0)
+    assert widget.state.properties["flags"] == 16
+    assert widget._color == [0.8, 0.2, 0.2, 1.0]
+
+
+def test_color_button_widget_with_size():
+    """Test ColorButtonWidget with custom size."""
+    widget = ColorButtonWidget("btn-color-3", size=(50.0, 50.0))
+
+    assert widget.state.properties["size"] == (50.0, 50.0)
+
+
+def test_color_button_widget_get_color():
+    """Test ColorButtonWidget get_color method."""
+    widget = ColorButtonWidget("btn-color-4", color=(0.1, 0.2, 0.3, 0.4))
+
+    assert widget.get_color() == (0.1, 0.2, 0.3, 0.4)
+
+
+def test_color_button_widget_set_color():
+    """Test ColorButtonWidget set_color method."""
+    widget = ColorButtonWidget("btn-color-5")
+
+    widget.set_color((0.9, 0.8, 0.7, 0.6))
+    assert widget.get_color() == (0.9, 0.8, 0.7, 0.6)
+    assert widget.state.properties["color"] == (0.9, 0.8, 0.7, 0.6)
+
+
+# ==============================================================================
+# Edge Cases and Coverage
+# ==============================================================================
+
+
+def test_widget_visibility_affects_render():
+    """Test that invisible widgets respect visibility flag."""
+    color_edit3 = ColorEdit3Widget("vis-1")
+    color_edit4 = ColorEdit4Widget("vis-2")
+    color_picker3 = ColorPicker3Widget("vis-3")
+    color_picker4 = ColorPickerWidget("vis-4")
+    color_button = ColorButtonWidget("vis-5")
+
+    # Set invisible
+    color_edit3.set_visible(False)
+    color_edit4.set_visible(False)
+    color_picker3.set_visible(False)
+    color_picker4.set_visible(False)
+    color_button.set_visible(False)
+
+    assert color_edit3.state.visible is False
+    assert color_edit4.state.visible is False
+    assert color_picker3.state.visible is False
+    assert color_picker4.state.visible is False
+    assert color_button.state.visible is False
+
+
+def test_all_color_widgets_have_state():
+    """Test that all color widgets have proper state."""
+    widgets = [
+        ColorEdit3Widget("w1"),
+        ColorEdit4Widget("w2"),
+        ColorPicker3Widget("w3"),
+        ColorPickerWidget("w4"),
+        ColorButtonWidget("w5"),
+    ]
+
+    for widget in widgets:
+        assert isinstance(widget.state, WidgetState)
+        assert widget.state.widget_id is not None
+        assert widget.state.widget_type is not None

--- a/tests/test_color_widgets_render.py
+++ b/tests/test_color_widgets_render.py
@@ -1,0 +1,304 @@
+"""Render tests for color widgets using mocks.
+
+These tests verify render() method behavior by mocking imgui calls.
+They ensure render methods handle visibility, call correct ImGui functions,
+and trigger callbacks appropriately.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from champi_imgui.widgets.color import (
+    ColorButtonWidget,
+    ColorEdit3Widget,
+    ColorEdit4Widget,
+    ColorPicker3Widget,
+    ColorPickerWidget,
+)
+
+# ==============================================================================
+# ColorEdit3Widget Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.color.imgui")
+def test_color_edit3_widget_render(mock_imgui):
+    """Test ColorEdit3Widget render method."""
+    mock_imgui.color_edit3.return_value = (False, [0.5, 0.5, 0.5])
+    widget = ColorEdit3Widget("color3-1", color=(0.5, 0.5, 0.5))
+
+    result = widget.render()
+
+    assert result == (0.5, 0.5, 0.5)
+    mock_imgui.color_edit3.assert_called_once()
+
+
+@patch("champi_imgui.widgets.color.imgui")
+def test_color_edit3_widget_render_invisible(mock_imgui):
+    """Test ColorEdit3Widget render when invisible."""
+    widget = ColorEdit3Widget("color3-2", color=(0.1, 0.2, 0.3))
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result == (0.1, 0.2, 0.3)
+    mock_imgui.color_edit3.assert_not_called()
+
+
+@patch("champi_imgui.widgets.color.imgui")
+def test_color_edit3_widget_color_changed(mock_imgui):
+    """Test ColorEdit3Widget triggers callback on color change."""
+    mock_imgui.color_edit3.return_value = (True, [0.9, 0.8, 0.7])
+    widget = ColorEdit3Widget("color3-3", color=(0.5, 0.5, 0.5))
+
+    callback_colors = []
+
+    def on_change(color):
+        callback_colors.append(color)
+
+    widget.register_callback("on_change", on_change)
+    result = widget.render()
+
+    assert result == (0.9, 0.8, 0.7)
+    assert widget.state.properties["color"] == (0.9, 0.8, 0.7)
+    assert callback_colors == [(0.9, 0.8, 0.7)]
+
+
+# ==============================================================================
+# ColorEdit4Widget Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.color.imgui")
+def test_color_edit4_widget_render(mock_imgui):
+    """Test ColorEdit4Widget render method."""
+    mock_imgui.color_edit4.return_value = (False, [0.5, 0.5, 0.5, 1.0])
+    widget = ColorEdit4Widget("color4-1", color=(0.5, 0.5, 0.5, 1.0))
+
+    result = widget.render()
+
+    assert result == (0.5, 0.5, 0.5, 1.0)
+    mock_imgui.color_edit4.assert_called_once()
+
+
+@patch("champi_imgui.widgets.color.imgui")
+def test_color_edit4_widget_render_invisible(mock_imgui):
+    """Test ColorEdit4Widget render when invisible."""
+    widget = ColorEdit4Widget("color4-2", color=(0.1, 0.2, 0.3, 0.4))
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result == (0.1, 0.2, 0.3, 0.4)
+    mock_imgui.color_edit4.assert_not_called()
+
+
+@patch("champi_imgui.widgets.color.imgui")
+def test_color_edit4_widget_color_changed(mock_imgui):
+    """Test ColorEdit4Widget triggers callback on color change."""
+    mock_imgui.color_edit4.return_value = (True, [0.9, 0.8, 0.7, 0.6])
+    widget = ColorEdit4Widget("color4-3", color=(0.5, 0.5, 0.5, 1.0))
+
+    callback_colors = []
+
+    def on_change(color):
+        callback_colors.append(color)
+
+    widget.register_callback("on_change", on_change)
+    result = widget.render()
+
+    assert result == (0.9, 0.8, 0.7, 0.6)
+    assert callback_colors == [(0.9, 0.8, 0.7, 0.6)]
+
+
+# ==============================================================================
+# ColorPicker3Widget Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.color.imgui")
+def test_color_picker3_widget_render(mock_imgui):
+    """Test ColorPicker3Widget render method."""
+    mock_imgui.color_picker3.return_value = (False, [0.5, 0.5, 0.5])
+    widget = ColorPicker3Widget("picker3-1", color=(0.5, 0.5, 0.5))
+
+    result = widget.render()
+
+    assert result == (0.5, 0.5, 0.5)
+    mock_imgui.color_picker3.assert_called_once()
+
+
+@patch("champi_imgui.widgets.color.imgui")
+def test_color_picker3_widget_render_invisible(mock_imgui):
+    """Test ColorPicker3Widget render when invisible."""
+    widget = ColorPicker3Widget("picker3-2", color=(0.2, 0.4, 0.6))
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result == (0.2, 0.4, 0.6)
+    mock_imgui.color_picker3.assert_not_called()
+
+
+@patch("champi_imgui.widgets.color.imgui")
+def test_color_picker3_widget_color_changed(mock_imgui):
+    """Test ColorPicker3Widget triggers callback on color change."""
+    mock_imgui.color_picker3.return_value = (True, [0.1, 0.3, 0.5])
+    widget = ColorPicker3Widget("picker3-3", color=(0.5, 0.5, 0.5))
+
+    callback_colors = []
+
+    def on_change(color):
+        callback_colors.append(color)
+
+    widget.register_callback("on_change", on_change)
+    result = widget.render()
+
+    assert result == (0.1, 0.3, 0.5)
+    assert callback_colors == [(0.1, 0.3, 0.5)]
+
+
+# ==============================================================================
+# ColorPickerWidget Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.color.imgui")
+def test_color_picker_widget_render(mock_imgui):
+    """Test ColorPickerWidget render method."""
+    # Mock ImVec4 return value
+    mock_color = MagicMock()
+    mock_color.x = 0.5
+    mock_color.y = 0.5
+    mock_color.z = 0.5
+    mock_color.w = 1.0
+    mock_imgui.color_picker4.return_value = (False, mock_color)
+    widget = ColorPickerWidget("picker4-1", color=(0.5, 0.5, 0.5, 1.0))
+
+    result = widget.render()
+
+    assert result == (0.5, 0.5, 0.5, 1.0)
+    mock_imgui.color_picker4.assert_called_once()
+
+
+@patch("champi_imgui.widgets.color.imgui")
+def test_color_picker_widget_render_invisible(mock_imgui):
+    """Test ColorPickerWidget render when invisible."""
+    widget = ColorPickerWidget("picker4-2", color=(0.2, 0.4, 0.6, 0.8))
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result == (0.2, 0.4, 0.6, 0.8)
+    mock_imgui.color_picker4.assert_not_called()
+
+
+@patch("champi_imgui.widgets.color.imgui")
+def test_color_picker_widget_color_changed(mock_imgui):
+    """Test ColorPickerWidget triggers callback on color change."""
+    # Mock ImVec4 return value
+    mock_color = MagicMock()
+    mock_color.x = 0.1
+    mock_color.y = 0.3
+    mock_color.z = 0.5
+    mock_color.w = 0.7
+    mock_imgui.color_picker4.return_value = (True, mock_color)
+    widget = ColorPickerWidget("picker4-3", color=(0.5, 0.5, 0.5, 1.0))
+
+    callback_colors = []
+
+    def on_change(color):
+        callback_colors.append(color)
+
+    widget.register_callback("on_change", on_change)
+    result = widget.render()
+
+    assert result == (0.1, 0.3, 0.5, 0.7)
+    assert callback_colors == [(0.1, 0.3, 0.5, 0.7)]
+
+
+@patch("champi_imgui.widgets.color.imgui")
+def test_color_picker_widget_with_ref_col(mock_imgui):
+    """Test ColorPickerWidget render with reference color."""
+    mock_color = MagicMock()
+    mock_color.x = 0.5
+    mock_color.y = 0.5
+    mock_color.z = 0.5
+    mock_color.w = 1.0
+    mock_imgui.color_picker4.return_value = (False, mock_color)
+    widget = ColorPickerWidget(
+        "picker4-4", color=(0.5, 0.5, 0.5, 1.0), ref_col=[0.0, 0.0, 0.0, 1.0]
+    )
+
+    widget.render()
+
+    # Verify ref_col was passed to imgui.color_picker4
+    call_args = mock_imgui.color_picker4.call_args
+    assert call_args is not None
+    assert len(call_args[0]) == 4  # label, color, flags, ref_col
+
+
+# ==============================================================================
+# ColorButtonWidget Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.color.imgui")
+def test_color_button_widget_render(mock_imgui):
+    """Test ColorButtonWidget render method."""
+    mock_imgui.color_button.return_value = False
+    mock_imgui.ImVec4 = MagicMock(return_value="mock_vec4")
+    widget = ColorButtonWidget("btn-color-1", color=(0.8, 0.2, 0.2, 1.0))
+
+    result = widget.render()
+
+    assert result is False
+    mock_imgui.color_button.assert_called_once()
+
+
+@patch("champi_imgui.widgets.color.imgui")
+def test_color_button_widget_render_invisible(mock_imgui):
+    """Test ColorButtonWidget render when invisible."""
+    widget = ColorButtonWidget("btn-color-2", color=(0.5, 0.5, 0.5, 1.0))
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result is False
+    mock_imgui.color_button.assert_not_called()
+
+
+@patch("champi_imgui.widgets.color.imgui")
+def test_color_button_widget_clicked(mock_imgui):
+    """Test ColorButtonWidget triggers callback on click."""
+    mock_imgui.color_button.return_value = True
+    mock_imgui.ImVec4 = MagicMock(return_value="mock_vec4")
+    widget = ColorButtonWidget("btn-color-3", color=(0.9, 0.1, 0.1, 1.0))
+
+    callback_colors = []
+
+    def on_click(color):
+        callback_colors.append(color)
+
+    widget.register_callback("on_click", on_click)
+    result = widget.render()
+
+    assert result is True
+    assert callback_colors == [(0.9, 0.1, 0.1, 1.0)]
+
+
+@patch("champi_imgui.widgets.color.imgui")
+def test_color_button_widget_with_size(mock_imgui):
+    """Test ColorButtonWidget render with custom size."""
+    mock_imgui.color_button.return_value = False
+    mock_imgui.ImVec4 = MagicMock(return_value="mock_vec4")
+    mock_imgui.ImVec2 = MagicMock(return_value="mock_vec2")
+    widget = ColorButtonWidget(
+        "btn-color-4", color=(0.5, 0.5, 0.5, 1.0), size=(50.0, 50.0)
+    )
+
+    widget.render()
+
+    # Verify size was passed to imgui.color_button
+    call_args = mock_imgui.color_button.call_args
+    assert call_args is not None
+    assert len(call_args[0]) == 4  # widget_id, color_vec, flags, size

--- a/tests/test_input_widgets.py
+++ b/tests/test_input_widgets.py
@@ -1,0 +1,446 @@
+"""Comprehensive tests for input widgets.
+
+Tests cover all 9 input widgets:
+- InputIntWidget, InputFloatWidget, InputDoubleWidget, InputScalarWidget
+- RadioButtonWidget, ComboWidget, ListBoxWidget
+- SelectableWidget, CheckboxFlagsWidget
+"""
+
+from champi_imgui.core.state import WidgetState
+from champi_imgui.widgets.input import (
+    CheckboxFlagsWidget,
+    ComboWidget,
+    InputDoubleWidget,
+    InputFloatWidget,
+    InputIntWidget,
+    InputScalarWidget,
+    ListBoxWidget,
+    RadioButtonWidget,
+    SelectableWidget,
+)
+
+# ==============================================================================
+# InputIntWidget Tests
+# ==============================================================================
+
+
+def test_input_int_widget_creation():
+    """Test InputIntWidget creation with default values."""
+    widget = InputIntWidget("int-1")
+
+    assert widget.widget_id == "int-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_type == "InputIntWidget"
+    assert widget.state.properties["label"] == "Input Int"
+    assert widget.state.properties["value"] == 0
+    assert widget._value == 0
+
+
+def test_input_int_widget_with_value():
+    """Test InputIntWidget with custom value."""
+    widget = InputIntWidget("int-2", label="Age", value=25, step=1, step_fast=10)
+
+    assert widget.state.properties["label"] == "Age"
+    assert widget.state.properties["value"] == 25
+    assert widget.state.properties["step"] == 1
+    assert widget.state.properties["step_fast"] == 10
+    assert widget._value == 25
+
+
+def test_input_int_widget_get_value():
+    """Test InputIntWidget get_value method."""
+    widget = InputIntWidget("int-3", value=100)
+
+    assert widget.get_value() == 100
+
+
+def test_input_int_widget_set_value():
+    """Test InputIntWidget set_value method."""
+    widget = InputIntWidget("int-4", value=0)
+
+    widget.set_value(50)
+    assert widget.get_value() == 50
+    assert widget.state.properties["value"] == 50
+
+
+# ==============================================================================
+# InputFloatWidget Tests
+# ==============================================================================
+
+
+def test_input_float_widget_creation():
+    """Test InputFloatWidget creation."""
+    widget = InputFloatWidget("float-1")
+
+    assert widget.widget_id == "float-1"
+    assert widget.state.widget_type == "InputFloatWidget"
+    assert widget.state.properties["value"] == 0.0
+    assert widget._value == 0.0
+
+
+def test_input_float_widget_with_value():
+    """Test InputFloatWidget with custom value."""
+    widget = InputFloatWidget(
+        "float-2",
+        label="Price",
+        value=19.99,
+        step=0.1,
+        step_fast=1.0,
+        format_str="%.2f",
+    )
+
+    assert widget.state.properties["label"] == "Price"
+    assert widget.state.properties["value"] == 19.99
+    assert widget.state.properties["step"] == 0.1
+    assert widget.state.properties["step_fast"] == 1.0
+    assert widget.state.properties["format"] == "%.2f"
+
+
+def test_input_float_widget_get_set_value():
+    """Test InputFloatWidget get/set value."""
+    widget = InputFloatWidget("float-3", value=1.5)
+
+    assert widget.get_value() == 1.5
+
+    widget.set_value(2.5)
+    assert widget.get_value() == 2.5
+    assert widget.state.properties["value"] == 2.5
+
+
+# ==============================================================================
+# InputDoubleWidget Tests
+# ==============================================================================
+
+
+def test_input_double_widget_creation():
+    """Test InputDoubleWidget creation."""
+    widget = InputDoubleWidget("double-1")
+
+    assert widget.widget_id == "double-1"
+    assert widget.state.widget_type == "InputDoubleWidget"
+    assert widget.state.properties["format"] == "%.6f"
+
+
+def test_input_double_widget_with_value():
+    """Test InputDoubleWidget with custom value."""
+    widget = InputDoubleWidget(
+        "double-2", label="Precision", value=3.141592653589793, format_str="%.10f"
+    )
+
+    assert widget.state.properties["label"] == "Precision"
+    assert widget.state.properties["value"] == 3.141592653589793
+    assert widget.state.properties["format"] == "%.10f"
+
+
+def test_input_double_widget_get_set_value():
+    """Test InputDoubleWidget get/set value."""
+    widget = InputDoubleWidget("double-3", value=1.0)
+
+    assert widget.get_value() == 1.0
+
+    widget.set_value(2.71828)
+    assert widget.get_value() == 2.71828
+
+
+# ==============================================================================
+# InputScalarWidget Tests
+# ==============================================================================
+
+
+def test_input_scalar_widget_creation():
+    """Test InputScalarWidget creation."""
+    widget = InputScalarWidget("scalar-1")
+
+    assert widget.widget_id == "scalar-1"
+    assert widget.state.widget_type == "InputScalarWidget"
+    assert widget._value == 0.0
+
+
+def test_input_scalar_widget_with_value():
+    """Test InputScalarWidget with custom value."""
+    widget = InputScalarWidget("scalar-2", label="Custom", value=42.0)
+
+    assert widget.state.properties["label"] == "Custom"
+    assert widget.state.properties["value"] == 42.0
+
+
+def test_input_scalar_widget_get_value():
+    """Test InputScalarWidget get_value."""
+    widget = InputScalarWidget("scalar-3", value=123.45)
+
+    assert widget.get_value() == 123.45
+
+
+# ==============================================================================
+# RadioButtonWidget Tests
+# ==============================================================================
+
+
+def test_radio_button_widget_creation():
+    """Test RadioButtonWidget creation."""
+    widget = RadioButtonWidget("radio-1")
+
+    assert widget.widget_id == "radio-1"
+    assert widget.state.widget_type == "RadioButtonWidget"
+    assert widget.state.properties["label"] == "Radio"
+    assert widget.state.properties["active"] is False
+    assert widget._active is False
+
+
+def test_radio_button_widget_with_active():
+    """Test RadioButtonWidget with active state."""
+    widget = RadioButtonWidget("radio-2", label="Option A", active=True)
+
+    assert widget.state.properties["label"] == "Option A"
+    assert widget.state.properties["active"] is True
+    assert widget._active is True
+
+
+def test_radio_button_widget_is_active():
+    """Test RadioButtonWidget is_active method."""
+    widget = RadioButtonWidget("radio-3", active=True)
+
+    assert widget.is_active() is True
+
+
+def test_radio_button_widget_set_active():
+    """Test RadioButtonWidget set_active method."""
+    widget = RadioButtonWidget("radio-4", active=False)
+
+    widget.set_active(True)
+    assert widget.is_active() is True
+    assert widget.state.properties["active"] is True
+
+
+# ==============================================================================
+# ComboWidget Tests
+# ==============================================================================
+
+
+def test_combo_widget_creation():
+    """Test ComboWidget creation."""
+    widget = ComboWidget("combo-1")
+
+    assert widget.widget_id == "combo-1"
+    assert widget.state.widget_type == "ComboWidget"
+    assert widget.state.properties["label"] == "Combo"
+    assert widget.state.properties["items"] == []
+    assert widget.state.properties["current_item"] == 0
+
+
+def test_combo_widget_with_items():
+    """Test ComboWidget with items."""
+    items = ["Option 1", "Option 2", "Option 3"]
+    widget = ComboWidget("combo-2", label="Select", items=items, current_item=1)
+
+    assert widget.state.properties["label"] == "Select"
+    assert widget.state.properties["items"] == items
+    assert widget.state.properties["current_item"] == 1
+    assert widget._current_item == 1
+
+
+def test_combo_widget_get_current_item():
+    """Test ComboWidget get_current_item."""
+    widget = ComboWidget("combo-3", items=["A", "B", "C"], current_item=2)
+
+    assert widget.get_current_item() == 2
+
+
+def test_combo_widget_get_current_value():
+    """Test ComboWidget get_current_value."""
+    items = ["Red", "Green", "Blue"]
+    widget = ComboWidget("combo-4", items=items, current_item=1)
+
+    assert widget.get_current_value() == "Green"
+
+
+def test_combo_widget_get_current_value_empty():
+    """Test ComboWidget get_current_value with empty items."""
+    widget = ComboWidget("combo-5", items=[])
+
+    assert widget.get_current_value() is None
+
+
+def test_combo_widget_set_items():
+    """Test ComboWidget set_items method."""
+    widget = ComboWidget("combo-6", items=["A", "B"])
+
+    widget.set_items(["X", "Y", "Z"])
+    assert widget.state.properties["items"] == ["X", "Y", "Z"]
+
+
+# ==============================================================================
+# ListBoxWidget Tests
+# ==============================================================================
+
+
+def test_listbox_widget_creation():
+    """Test ListBoxWidget creation."""
+    widget = ListBoxWidget("list-1")
+
+    assert widget.widget_id == "list-1"
+    assert widget.state.widget_type == "ListBoxWidget"
+    assert widget.state.properties["label"] == "ListBox"
+    assert widget.state.properties["items"] == []
+
+
+def test_listbox_widget_with_items():
+    """Test ListBoxWidget with items."""
+    items = ["Item 1", "Item 2", "Item 3"]
+    widget = ListBoxWidget("list-2", label="Choose", items=items, current_item=2)
+
+    assert widget.state.properties["label"] == "Choose"
+    assert widget.state.properties["items"] == items
+    assert widget.state.properties["current_item"] == 2
+
+
+def test_listbox_widget_get_current_item():
+    """Test ListBoxWidget get_current_item."""
+    widget = ListBoxWidget("list-3", items=["A", "B", "C"], current_item=1)
+
+    assert widget.get_current_item() == 1
+
+
+def test_listbox_widget_get_current_value():
+    """Test ListBoxWidget get_current_value."""
+    items = ["Apple", "Banana", "Cherry"]
+    widget = ListBoxWidget("list-4", items=items, current_item=2)
+
+    assert widget.get_current_value() == "Cherry"
+
+
+def test_listbox_widget_height_in_items():
+    """Test ListBoxWidget height_in_items property."""
+    widget = ListBoxWidget("list-5", items=["A", "B"], height_in_items=5)
+
+    assert widget.state.properties["height_in_items"] == 5
+
+
+# ==============================================================================
+# SelectableWidget Tests
+# ==============================================================================
+
+
+def test_selectable_widget_creation():
+    """Test SelectableWidget creation."""
+    widget = SelectableWidget("sel-1")
+
+    assert widget.widget_id == "sel-1"
+    assert widget.state.widget_type == "SelectableWidget"
+    assert widget.state.properties["label"] == "Selectable"
+    assert widget.state.properties["selected"] is False
+    assert widget._selected is False
+
+
+def test_selectable_widget_with_selected():
+    """Test SelectableWidget with selected state."""
+    widget = SelectableWidget("sel-2", label="Item", selected=True)
+
+    assert widget.state.properties["label"] == "Item"
+    assert widget.state.properties["selected"] is True
+    assert widget._selected is True
+
+
+def test_selectable_widget_is_selected():
+    """Test SelectableWidget is_selected method."""
+    widget = SelectableWidget("sel-3", selected=True)
+
+    assert widget.is_selected() is True
+
+
+def test_selectable_widget_set_selected():
+    """Test SelectableWidget set_selected method."""
+    widget = SelectableWidget("sel-4", selected=False)
+
+    widget.set_selected(True)
+    assert widget.is_selected() is True
+    assert widget.state.properties["selected"] is True
+
+
+def test_selectable_widget_with_size():
+    """Test SelectableWidget with size."""
+    widget = SelectableWidget("sel-5", size=(200.0, 30.0))
+
+    assert widget.state.properties["size"] == (200.0, 30.0)
+
+
+# ==============================================================================
+# CheckboxFlagsWidget Tests
+# ==============================================================================
+
+
+def test_checkbox_flags_widget_creation():
+    """Test CheckboxFlagsWidget creation."""
+    widget = CheckboxFlagsWidget("flags-1")
+
+    assert widget.widget_id == "flags-1"
+    assert widget.state.widget_type == "CheckboxFlagsWidget"
+    assert widget.state.properties["label"] == "Checkbox Flags"
+    assert widget.state.properties["flags"] == 0
+    assert widget._flags == 0
+
+
+def test_checkbox_flags_widget_with_flags():
+    """Test CheckboxFlagsWidget with custom flags."""
+    widget = CheckboxFlagsWidget("flags-2", label="Options", flags=5, flags_value=2)
+
+    assert widget.state.properties["label"] == "Options"
+    assert widget.state.properties["flags"] == 5
+    assert widget.state.properties["flags_value"] == 2
+
+
+def test_checkbox_flags_widget_get_flags():
+    """Test CheckboxFlagsWidget get_flags method."""
+    widget = CheckboxFlagsWidget("flags-3", flags=7)
+
+    assert widget.get_flags() == 7
+
+
+def test_checkbox_flags_widget_set_flags():
+    """Test CheckboxFlagsWidget set_flags method."""
+    widget = CheckboxFlagsWidget("flags-4", flags=0)
+
+    widget.set_flags(15)
+    assert widget.get_flags() == 15
+    assert widget.state.properties["flags"] == 15
+
+
+# ==============================================================================
+# Edge Cases and Coverage
+# ==============================================================================
+
+
+def test_widget_visibility_affects_render():
+    """Test that invisible widgets respect visibility flag."""
+    int_input = InputIntWidget("vis-1")
+    combo = ComboWidget("vis-2")
+    selectable = SelectableWidget("vis-3")
+
+    # Set invisible
+    int_input.set_visible(False)
+    combo.set_visible(False)
+    selectable.set_visible(False)
+
+    assert int_input.state.visible is False
+    assert combo.state.visible is False
+    assert selectable.state.visible is False
+
+
+def test_all_input_widgets_have_state():
+    """Test that all input widgets have proper state."""
+    widgets = [
+        InputIntWidget("w1"),
+        InputFloatWidget("w2"),
+        InputDoubleWidget("w3"),
+        InputScalarWidget("w4"),
+        RadioButtonWidget("w5"),
+        ComboWidget("w6"),
+        ListBoxWidget("w7"),
+        SelectableWidget("w8"),
+        CheckboxFlagsWidget("w9"),
+    ]
+
+    for widget in widgets:
+        assert isinstance(widget.state, WidgetState)
+        assert widget.state.widget_id is not None
+        assert widget.state.widget_type is not None

--- a/tests/test_input_widgets_render.py
+++ b/tests/test_input_widgets_render.py
@@ -1,0 +1,445 @@
+"""Render tests for input widgets using mocks.
+
+These tests verify render() method behavior by mocking imgui calls.
+They ensure render methods handle visibility, call correct ImGui functions,
+and trigger callbacks appropriately.
+"""
+
+from unittest.mock import patch
+
+from champi_imgui.widgets.input import (
+    CheckboxFlagsWidget,
+    ComboWidget,
+    InputDoubleWidget,
+    InputFloatWidget,
+    InputIntWidget,
+    InputScalarWidget,
+    ListBoxWidget,
+    RadioButtonWidget,
+    SelectableWidget,
+)
+
+# ==============================================================================
+# InputIntWidget Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_input_int_widget_render(mock_imgui):
+    """Test InputIntWidget render method."""
+    mock_imgui.input_int.return_value = (False, 42)
+    widget = InputIntWidget("int-1", value=42)
+
+    result = widget.render()
+
+    assert result == 42
+    mock_imgui.input_int.assert_called_once()
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_input_int_widget_render_invisible(mock_imgui):
+    """Test InputIntWidget render when invisible."""
+    widget = InputIntWidget("int-2", value=10)
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result == 10
+    mock_imgui.input_int.assert_not_called()
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_input_int_widget_value_changed(mock_imgui):
+    """Test InputIntWidget triggers callback on value change."""
+    mock_imgui.input_int.return_value = (True, 100)
+    widget = InputIntWidget("int-3", value=50)
+
+    callback_values = []
+
+    def on_change(value):
+        callback_values.append(value)
+
+    widget.register_callback("on_change", on_change)
+    result = widget.render()
+
+    assert result == 100
+    assert widget.state.properties["value"] == 100
+    assert callback_values == [100]
+
+
+# ==============================================================================
+# InputFloatWidget Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_input_float_widget_render(mock_imgui):
+    """Test InputFloatWidget render method."""
+    mock_imgui.input_float.return_value = (False, 3.14)
+    widget = InputFloatWidget("float-1", value=3.14)
+
+    result = widget.render()
+
+    assert result == 3.14
+    mock_imgui.input_float.assert_called_once()
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_input_float_widget_render_invisible(mock_imgui):
+    """Test InputFloatWidget render when invisible."""
+    widget = InputFloatWidget("float-2", value=2.5)
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result == 2.5
+    mock_imgui.input_float.assert_not_called()
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_input_float_widget_value_changed(mock_imgui):
+    """Test InputFloatWidget triggers callback on value change."""
+    mock_imgui.input_float.return_value = (True, 5.5)
+    widget = InputFloatWidget("float-3", value=1.0)
+
+    callback_values = []
+
+    def on_change(value):
+        callback_values.append(value)
+
+    widget.register_callback("on_change", on_change)
+    result = widget.render()
+
+    assert result == 5.5
+    assert callback_values == [5.5]
+
+
+# ==============================================================================
+# InputDoubleWidget Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_input_double_widget_render(mock_imgui):
+    """Test InputDoubleWidget render method."""
+    mock_imgui.input_double.return_value = (False, 3.141592653589793)
+    widget = InputDoubleWidget("double-1", value=3.141592653589793)
+
+    result = widget.render()
+
+    assert result == 3.141592653589793
+    mock_imgui.input_double.assert_called_once()
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_input_double_widget_render_invisible(mock_imgui):
+    """Test InputDoubleWidget render when invisible."""
+    widget = InputDoubleWidget("double-2", value=1.0)
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result == 1.0
+    mock_imgui.input_double.assert_not_called()
+
+
+# ==============================================================================
+# InputScalarWidget Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_input_scalar_widget_render(mock_imgui):
+    """Test InputScalarWidget render method."""
+    mock_imgui.input_float.return_value = (False, 42.0)
+    widget = InputScalarWidget("scalar-1", value=42.0)
+
+    result = widget.render()
+
+    assert result == 42.0
+    mock_imgui.input_float.assert_called_once()
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_input_scalar_widget_render_invisible(mock_imgui):
+    """Test InputScalarWidget render when invisible."""
+    widget = InputScalarWidget("scalar-2", value=10.0)
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result == 10.0
+    mock_imgui.input_float.assert_not_called()
+
+
+# ==============================================================================
+# RadioButtonWidget Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_radio_button_widget_render(mock_imgui):
+    """Test RadioButtonWidget render method."""
+    mock_imgui.radio_button.return_value = False
+    widget = RadioButtonWidget("radio-1", label="Option")
+
+    result = widget.render()
+
+    assert result is False
+    mock_imgui.radio_button.assert_called_once_with("Option", False)
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_radio_button_widget_render_invisible(mock_imgui):
+    """Test RadioButtonWidget render when invisible."""
+    widget = RadioButtonWidget("radio-2")
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result is False
+    mock_imgui.radio_button.assert_not_called()
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_radio_button_widget_clicked(mock_imgui):
+    """Test RadioButtonWidget triggers callback on click."""
+    mock_imgui.radio_button.return_value = True
+    widget = RadioButtonWidget("radio-3", active=False)
+
+    callback_states = []
+
+    def on_click(active):
+        callback_states.append(active)
+
+    widget.register_callback("on_click", on_click)
+    result = widget.render()
+
+    assert result is True
+    assert widget._active is True
+    assert callback_states == [True]
+
+
+# ==============================================================================
+# ComboWidget Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_combo_widget_render(mock_imgui):
+    """Test ComboWidget render method."""
+    mock_imgui.combo.return_value = (False, 1)
+    items = ["A", "B", "C"]
+    widget = ComboWidget("combo-1", items=items, current_item=1)
+
+    result = widget.render()
+
+    assert result == 1
+    mock_imgui.combo.assert_called_once()
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_combo_widget_render_invisible(mock_imgui):
+    """Test ComboWidget render when invisible."""
+    widget = ComboWidget("combo-2", items=["A", "B"], current_item=0)
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result == 0
+    mock_imgui.combo.assert_not_called()
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_combo_widget_render_empty_items(mock_imgui):
+    """Test ComboWidget render with empty items."""
+    widget = ComboWidget("combo-3", items=[])
+
+    result = widget.render()
+
+    assert result == 0
+    mock_imgui.combo.assert_not_called()
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_combo_widget_selection_changed(mock_imgui):
+    """Test ComboWidget triggers callback on selection change."""
+    mock_imgui.combo.return_value = (True, 2)
+    items = ["Red", "Green", "Blue"]
+    widget = ComboWidget("combo-4", items=items, current_item=0)
+
+    callback_data = []
+
+    def on_change(index, value):
+        callback_data.append((index, value))
+
+    widget.register_callback("on_change", on_change)
+    result = widget.render()
+
+    assert result == 2
+    assert callback_data == [(2, "Blue")]
+
+
+# ==============================================================================
+# ListBoxWidget Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_listbox_widget_render(mock_imgui):
+    """Test ListBoxWidget render method."""
+    mock_imgui.list_box.return_value = (False, 2)
+    items = ["Item 1", "Item 2", "Item 3"]
+    widget = ListBoxWidget("list-1", items=items, current_item=2)
+
+    result = widget.render()
+
+    assert result == 2
+    mock_imgui.list_box.assert_called_once()
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_listbox_widget_render_invisible(mock_imgui):
+    """Test ListBoxWidget render when invisible."""
+    widget = ListBoxWidget("list-2", items=["A"], current_item=0)
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result == 0
+    mock_imgui.list_box.assert_not_called()
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_listbox_widget_render_empty_items(mock_imgui):
+    """Test ListBoxWidget render with empty items."""
+    widget = ListBoxWidget("list-3", items=[])
+
+    result = widget.render()
+
+    assert result == 0
+    mock_imgui.list_box.assert_not_called()
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_listbox_widget_selection_changed(mock_imgui):
+    """Test ListBoxWidget triggers callback on selection change."""
+    mock_imgui.list_box.return_value = (True, 1)
+    items = ["Apple", "Banana", "Cherry"]
+    widget = ListBoxWidget("list-4", items=items, current_item=0)
+
+    callback_data = []
+
+    def on_change(index, value):
+        callback_data.append((index, value))
+
+    widget.register_callback("on_change", on_change)
+    result = widget.render()
+
+    assert result == 1
+    assert callback_data == [(1, "Banana")]
+
+
+# ==============================================================================
+# SelectableWidget Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_selectable_widget_render(mock_imgui):
+    """Test SelectableWidget render method."""
+    mock_imgui.selectable.return_value = (False, False)
+    widget = SelectableWidget("sel-1", label="Item")
+
+    result = widget.render()
+
+    assert result is False
+    mock_imgui.selectable.assert_called_once()
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_selectable_widget_render_invisible(mock_imgui):
+    """Test SelectableWidget render when invisible."""
+    widget = SelectableWidget("sel-2", selected=True)
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result is True
+    mock_imgui.selectable.assert_not_called()
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_selectable_widget_render_with_size(mock_imgui):
+    """Test SelectableWidget render with size."""
+    mock_imgui.selectable.return_value = (False, False)
+    widget = SelectableWidget("sel-3", size=(200.0, 30.0))
+
+    widget.render()
+
+    mock_imgui.selectable.assert_called_once()
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_selectable_widget_clicked(mock_imgui):
+    """Test SelectableWidget triggers callback on click."""
+    mock_imgui.selectable.return_value = (True, True)
+    widget = SelectableWidget("sel-4", selected=False)
+
+    callback_states = []
+
+    def on_click(selected):
+        callback_states.append(selected)
+
+    widget.register_callback("on_click", on_click)
+    result = widget.render()
+
+    assert result is True
+    assert callback_states == [True]
+
+
+# ==============================================================================
+# CheckboxFlagsWidget Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_checkbox_flags_widget_render(mock_imgui):
+    """Test CheckboxFlagsWidget render method."""
+    mock_imgui.checkbox_flags.return_value = (False, 5)
+    widget = CheckboxFlagsWidget("flags-1", flags=5, flags_value=2)
+
+    result = widget.render()
+
+    assert result == 5
+    mock_imgui.checkbox_flags.assert_called_once_with("Checkbox Flags", 5, 2)
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_checkbox_flags_widget_render_invisible(mock_imgui):
+    """Test CheckboxFlagsWidget render when invisible."""
+    widget = CheckboxFlagsWidget("flags-2", flags=3)
+    widget.set_visible(False)
+
+    result = widget.render()
+
+    assert result == 3
+    mock_imgui.checkbox_flags.assert_not_called()
+
+
+@patch("champi_imgui.widgets.input.imgui")
+def test_checkbox_flags_widget_changed(mock_imgui):
+    """Test CheckboxFlagsWidget triggers callback on change."""
+    mock_imgui.checkbox_flags.return_value = (True, 7)
+    widget = CheckboxFlagsWidget("flags-3", flags=5, flags_value=2)
+
+    callback_values = []
+
+    def on_change(flags):
+        callback_values.append(flags)
+
+    widget.register_callback("on_change", on_change)
+    result = widget.render()
+
+    assert result == 7
+    assert callback_values == [7]

--- a/tests/test_progress_widgets.py
+++ b/tests/test_progress_widgets.py
@@ -1,0 +1,234 @@
+"""Comprehensive tests for progress widgets.
+
+Tests cover all 3 progress widgets:
+- ProgressBarWidget
+- LoadingIndicatorWidget
+- StatusBarWidget
+"""
+
+from champi_imgui.core.state import WidgetState
+from champi_imgui.widgets.progress import (
+    LoadingIndicatorWidget,
+    ProgressBarWidget,
+    StatusBarWidget,
+)
+
+# ==============================================================================
+# ProgressBarWidget Tests
+# ==============================================================================
+
+
+def test_progress_bar_widget_creation():
+    """Test ProgressBarWidget creation with default values."""
+    widget = ProgressBarWidget("progress-1")
+
+    assert widget.widget_id == "progress-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_type == "ProgressBarWidget"
+    assert widget.state.properties["fraction"] == 0.0
+    assert widget.state.properties["size"] == (-1.0, 0.0)
+    assert widget.state.properties["overlay"] is None
+    assert widget._fraction == 0.0
+
+
+def test_progress_bar_widget_with_fraction():
+    """Test ProgressBarWidget with custom fraction."""
+    widget = ProgressBarWidget("progress-2", fraction=0.5, overlay="50%")
+
+    assert widget.state.properties["fraction"] == 0.5
+    assert widget.state.properties["overlay"] == "50%"
+    assert widget._fraction == 0.5
+
+
+def test_progress_bar_widget_with_size():
+    """Test ProgressBarWidget with custom size."""
+    widget = ProgressBarWidget("progress-3", size=(200.0, 20.0))
+
+    assert widget.state.properties["size"] == (200.0, 20.0)
+
+
+def test_progress_bar_widget_get_fraction():
+    """Test ProgressBarWidget get_fraction method."""
+    widget = ProgressBarWidget("progress-4", fraction=0.75)
+
+    assert widget.get_fraction() == 0.75
+
+
+def test_progress_bar_widget_set_fraction():
+    """Test ProgressBarWidget set_fraction method."""
+    widget = ProgressBarWidget("progress-5")
+
+    widget.set_fraction(0.8)
+    assert widget.get_fraction() == 0.8
+    assert widget.state.properties["fraction"] == 0.8
+
+
+def test_progress_bar_widget_set_fraction_clamps():
+    """Test ProgressBarWidget set_fraction clamps to 0.0-1.0."""
+    widget = ProgressBarWidget("progress-6")
+
+    # Test clamping to 1.0
+    widget.set_fraction(1.5)
+    assert widget.get_fraction() == 1.0
+
+    # Test clamping to 0.0
+    widget.set_fraction(-0.5)
+    assert widget.get_fraction() == 0.0
+
+
+# ==============================================================================
+# LoadingIndicatorWidget Tests
+# ==============================================================================
+
+
+def test_loading_indicator_widget_creation():
+    """Test LoadingIndicatorWidget creation."""
+    widget = LoadingIndicatorWidget("loading-1")
+
+    assert widget.widget_id == "loading-1"
+    assert widget.state.widget_type == "LoadingIndicatorWidget"
+    assert widget.state.properties["label"] == "Loading"
+    assert widget.state.properties["radius"] == 10.0
+    assert widget.state.properties["thickness"] == 3.0
+    assert widget.state.properties["color"] == (1.0, 1.0, 1.0, 1.0)
+
+
+def test_loading_indicator_widget_with_custom_props():
+    """Test LoadingIndicatorWidget with custom properties."""
+    widget = LoadingIndicatorWidget(
+        "loading-2",
+        label="Please Wait",
+        radius=15.0,
+        thickness=5.0,
+        color=(0.5, 0.5, 1.0, 1.0),
+    )
+
+    assert widget.state.properties["label"] == "Please Wait"
+    assert widget.state.properties["radius"] == 15.0
+    assert widget.state.properties["thickness"] == 5.0
+    assert widget.state.properties["color"] == (0.5, 0.5, 1.0, 1.0)
+
+
+# ==============================================================================
+# StatusBarWidget Tests
+# ==============================================================================
+
+
+def test_status_bar_widget_creation():
+    """Test StatusBarWidget creation."""
+    widget = StatusBarWidget("status-1")
+
+    assert widget.widget_id == "status-1"
+    assert widget.state.widget_type == "StatusBarWidget"
+    assert widget.state.properties["text"] == "Ready"
+    assert widget.state.properties["show_progress"] is False
+    assert widget.state.properties["progress_fraction"] == 0.0
+    assert widget._text == "Ready"
+    assert widget._progress_fraction == 0.0
+
+
+def test_status_bar_widget_with_text():
+    """Test StatusBarWidget with custom text."""
+    widget = StatusBarWidget("status-2", text="Processing...")
+
+    assert widget.state.properties["text"] == "Processing..."
+    assert widget._text == "Processing..."
+
+
+def test_status_bar_widget_with_progress():
+    """Test StatusBarWidget with progress enabled."""
+    widget = StatusBarWidget(
+        "status-3", text="Loading", show_progress=True, progress_fraction=0.6
+    )
+
+    assert widget.state.properties["show_progress"] is True
+    assert widget.state.properties["progress_fraction"] == 0.6
+    assert widget._progress_fraction == 0.6
+
+
+def test_status_bar_widget_get_text():
+    """Test StatusBarWidget get_text method."""
+    widget = StatusBarWidget("status-4", text="Done")
+
+    assert widget.get_text() == "Done"
+
+
+def test_status_bar_widget_set_text():
+    """Test StatusBarWidget set_text method."""
+    widget = StatusBarWidget("status-5")
+
+    widget.set_text("Working...")
+    assert widget.get_text() == "Working..."
+    assert widget.state.properties["text"] == "Working..."
+
+
+def test_status_bar_widget_get_progress_fraction():
+    """Test StatusBarWidget get_progress_fraction method."""
+    widget = StatusBarWidget("status-6", progress_fraction=0.4)
+
+    assert widget.get_progress_fraction() == 0.4
+
+
+def test_status_bar_widget_set_progress_fraction():
+    """Test StatusBarWidget set_progress_fraction method."""
+    widget = StatusBarWidget("status-7")
+
+    widget.set_progress_fraction(0.7)
+    assert widget.get_progress_fraction() == 0.7
+    assert widget.state.properties["progress_fraction"] == 0.7
+
+
+def test_status_bar_widget_set_progress_fraction_clamps():
+    """Test StatusBarWidget set_progress_fraction clamps to 0.0-1.0."""
+    widget = StatusBarWidget("status-8")
+
+    # Test clamping to 1.0
+    widget.set_progress_fraction(2.0)
+    assert widget.get_progress_fraction() == 1.0
+
+    # Test clamping to 0.0
+    widget.set_progress_fraction(-1.0)
+    assert widget.get_progress_fraction() == 0.0
+
+
+def test_status_bar_widget_set_show_progress():
+    """Test StatusBarWidget set_show_progress method."""
+    widget = StatusBarWidget("status-9", show_progress=False)
+
+    widget.set_show_progress(True)
+    assert widget.state.properties["show_progress"] is True
+
+
+# ==============================================================================
+# Edge Cases and Coverage
+# ==============================================================================
+
+
+def test_widget_visibility_affects_render():
+    """Test that invisible widgets respect visibility flag."""
+    progress_bar = ProgressBarWidget("vis-1")
+    loading_indicator = LoadingIndicatorWidget("vis-2")
+    status_bar = StatusBarWidget("vis-3")
+
+    # Set invisible
+    progress_bar.set_visible(False)
+    loading_indicator.set_visible(False)
+    status_bar.set_visible(False)
+
+    assert progress_bar.state.visible is False
+    assert loading_indicator.state.visible is False
+    assert status_bar.state.visible is False
+
+
+def test_all_progress_widgets_have_state():
+    """Test that all progress widgets have proper state."""
+    widgets = [
+        ProgressBarWidget("w1"),
+        LoadingIndicatorWidget("w2"),
+        StatusBarWidget("w3"),
+    ]
+
+    for widget in widgets:
+        assert isinstance(widget.state, WidgetState)
+        assert widget.state.widget_id is not None
+        assert widget.state.widget_type is not None

--- a/tests/test_progress_widgets_render.py
+++ b/tests/test_progress_widgets_render.py
@@ -1,0 +1,218 @@
+"""Render tests for progress widgets using mocks.
+
+These tests verify render() method behavior by mocking imgui calls.
+They ensure render methods handle visibility, call correct ImGui functions,
+and work correctly with different configurations.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from champi_imgui.widgets.progress import (
+    LoadingIndicatorWidget,
+    ProgressBarWidget,
+    StatusBarWidget,
+)
+
+# ==============================================================================
+# ProgressBarWidget Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.progress.imgui")
+def test_progress_bar_widget_render(mock_imgui):
+    """Test ProgressBarWidget render method."""
+    mock_imgui.ImVec2 = MagicMock(return_value="mock_vec2")
+    widget = ProgressBarWidget("progress-1", fraction=0.5)
+
+    widget.render()
+
+    mock_imgui.progress_bar.assert_called_once()
+    call_args = mock_imgui.progress_bar.call_args
+    assert call_args[0][0] == 0.5  # fraction
+
+
+@patch("champi_imgui.widgets.progress.imgui")
+def test_progress_bar_widget_render_invisible(mock_imgui):
+    """Test ProgressBarWidget render when invisible."""
+    widget = ProgressBarWidget("progress-2", fraction=0.5)
+    widget.set_visible(False)
+
+    widget.render()
+
+    mock_imgui.progress_bar.assert_not_called()
+
+
+@patch("champi_imgui.widgets.progress.imgui")
+def test_progress_bar_widget_render_with_overlay(mock_imgui):
+    """Test ProgressBarWidget render with overlay text."""
+    mock_imgui.ImVec2 = MagicMock(return_value="mock_vec2")
+    widget = ProgressBarWidget("progress-3", fraction=0.75, overlay="75%")
+
+    widget.render()
+
+    mock_imgui.progress_bar.assert_called_once()
+    call_args = mock_imgui.progress_bar.call_args
+    assert call_args[0][2] == "75%"  # overlay
+
+
+@patch("champi_imgui.widgets.progress.imgui")
+def test_progress_bar_widget_render_with_size(mock_imgui):
+    """Test ProgressBarWidget render with custom size."""
+    mock_imgui.ImVec2 = MagicMock(return_value="mock_vec2")
+    widget = ProgressBarWidget("progress-4", fraction=0.5, size=(300.0, 25.0))
+
+    widget.render()
+
+    mock_imgui.progress_bar.assert_called_once()
+    # Verify ImVec2 was created with size
+    mock_imgui.ImVec2.assert_called_once_with(300.0, 25.0)
+
+
+# ==============================================================================
+# LoadingIndicatorWidget Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.progress.imgui")
+def test_loading_indicator_widget_render(mock_imgui):
+    """Test LoadingIndicatorWidget render method."""
+    mock_imgui.get_window_draw_list.return_value = MagicMock()
+    mock_imgui.get_cursor_screen_pos.return_value = MagicMock(x=10.0, y=10.0)
+    # Mock ImVec2 to return an object with x and y attributes
+    mock_vec2 = MagicMock()
+    mock_vec2.x = 20.0
+    mock_vec2.y = 20.0
+    mock_imgui.ImVec2 = MagicMock(return_value=mock_vec2)
+    mock_imgui.get_time.return_value = 1.0
+    mock_imgui.ImVec4 = MagicMock(return_value="mock_vec4")
+    mock_imgui.get_color_u32.return_value = 0xFFFFFFFF
+    widget = LoadingIndicatorWidget("loading-1")
+
+    widget.render()
+
+    # Verify that drawing functions were called
+    mock_imgui.get_window_draw_list.assert_called_once()
+    mock_imgui.get_cursor_screen_pos.assert_called_once()
+    mock_imgui.dummy.assert_called_once()
+    mock_imgui.same_line.assert_called_once()
+    mock_imgui.text.assert_called_once_with("Loading")
+
+
+@patch("champi_imgui.widgets.progress.imgui")
+def test_loading_indicator_widget_render_invisible(mock_imgui):
+    """Test LoadingIndicatorWidget render when invisible."""
+    widget = LoadingIndicatorWidget("loading-2")
+    widget.set_visible(False)
+
+    widget.render()
+
+    mock_imgui.get_window_draw_list.assert_not_called()
+
+
+@patch("champi_imgui.widgets.progress.imgui")
+def test_loading_indicator_widget_render_custom_label(mock_imgui):
+    """Test LoadingIndicatorWidget render with custom label."""
+    mock_imgui.get_window_draw_list.return_value = MagicMock()
+    mock_imgui.get_cursor_screen_pos.return_value = MagicMock(x=10.0, y=10.0)
+    # Mock ImVec2 to return an object with x and y attributes
+    mock_vec2 = MagicMock()
+    mock_vec2.x = 20.0
+    mock_vec2.y = 20.0
+    mock_imgui.ImVec2 = MagicMock(return_value=mock_vec2)
+    mock_imgui.get_time.return_value = 1.0
+    mock_imgui.ImVec4 = MagicMock(return_value="mock_vec4")
+    mock_imgui.get_color_u32.return_value = 0xFFFFFFFF
+    widget = LoadingIndicatorWidget("loading-3", label="Please Wait")
+
+    widget.render()
+
+    mock_imgui.text.assert_called_once_with("Please Wait")
+
+
+@patch("champi_imgui.widgets.progress.imgui")
+def test_loading_indicator_widget_render_custom_radius(mock_imgui):
+    """Test LoadingIndicatorWidget render with custom radius."""
+    mock_imgui.get_window_draw_list.return_value = MagicMock()
+    mock_imgui.get_cursor_screen_pos.return_value = MagicMock(x=10.0, y=10.0)
+    # Mock ImVec2 to return an object with x and y attributes
+    mock_vec2 = MagicMock()
+    mock_vec2.x = 30.0
+    mock_vec2.y = 30.0
+    mock_imgui.ImVec2 = MagicMock(return_value=mock_vec2)
+    mock_imgui.get_time.return_value = 1.0
+    mock_imgui.ImVec4 = MagicMock(return_value="mock_vec4")
+    mock_imgui.get_color_u32.return_value = 0xFFFFFFFF
+    widget = LoadingIndicatorWidget("loading-4", radius=20.0)
+
+    widget.render()
+
+    # Verify dummy was called with correct size (radius * 2)
+    call_args = mock_imgui.dummy.call_args
+    assert call_args is not None
+
+
+# ==============================================================================
+# StatusBarWidget Render Tests
+# ==============================================================================
+
+
+@patch("champi_imgui.widgets.progress.imgui")
+def test_status_bar_widget_render(mock_imgui):
+    """Test StatusBarWidget render method."""
+    widget = StatusBarWidget("status-1", text="Ready")
+
+    widget.render()
+
+    mock_imgui.text.assert_called_once_with("Ready")
+    mock_imgui.progress_bar.assert_not_called()
+
+
+@patch("champi_imgui.widgets.progress.imgui")
+def test_status_bar_widget_render_invisible(mock_imgui):
+    """Test StatusBarWidget render when invisible."""
+    widget = StatusBarWidget("status-2", text="Ready")
+    widget.set_visible(False)
+
+    widget.render()
+
+    mock_imgui.text.assert_not_called()
+
+
+@patch("champi_imgui.widgets.progress.imgui")
+def test_status_bar_widget_render_with_progress(mock_imgui):
+    """Test StatusBarWidget render with progress bar."""
+    mock_imgui.ImVec2 = MagicMock(return_value="mock_vec2")
+    widget = StatusBarWidget(
+        "status-3", text="Loading", show_progress=True, progress_fraction=0.6
+    )
+
+    widget.render()
+
+    mock_imgui.text.assert_called_once_with("Loading")
+    mock_imgui.same_line.assert_called_once()
+    mock_imgui.progress_bar.assert_called_once()
+    call_args = mock_imgui.progress_bar.call_args
+    assert call_args[0][0] == 0.6  # progress_fraction
+
+
+@patch("champi_imgui.widgets.progress.imgui")
+def test_status_bar_widget_render_custom_text(mock_imgui):
+    """Test StatusBarWidget render with custom text."""
+    widget = StatusBarWidget("status-4", text="Processing...")
+
+    widget.render()
+
+    mock_imgui.text.assert_called_once_with("Processing...")
+
+
+@patch("champi_imgui.widgets.progress.imgui")
+def test_status_bar_widget_render_progress_disabled(mock_imgui):
+    """Test StatusBarWidget render with progress disabled."""
+    widget = StatusBarWidget(
+        "status-5", text="Done", show_progress=False, progress_fraction=1.0
+    )
+
+    widget.render()
+
+    mock_imgui.text.assert_called_once_with("Done")
+    mock_imgui.progress_bar.assert_not_called()

--- a/tests/test_widget_infrastructure.py
+++ b/tests/test_widget_infrastructure.py
@@ -1,0 +1,544 @@
+"""Comprehensive tests for widget infrastructure.
+
+Tests cover:
+- WidgetState dataclass and serialization
+- Widget ABC base class
+- WidgetFactory registration and creation
+- WidgetRegistry management
+- Signal emission
+"""
+
+import pytest
+
+from champi_imgui.core.state import WidgetState, widget_created, widget_updated
+from champi_imgui.core.widget import Widget, WidgetFactory, WidgetRegistry
+
+
+# Test Widget implementations (using Mock prefix to avoid pytest class detection)
+class MockTestWidget(Widget):
+    """Concrete widget implementation for testing."""
+
+    def __init__(self, widget_id: str, **props):
+        super().__init__(widget_id, **props)
+        self.render_count = 0
+
+    def render(self) -> str:
+        """Test render method."""
+        self.render_count += 1
+        return f"Rendered {self.widget_id}"
+
+
+class MockAnotherWidget(Widget):
+    """Another widget type for testing."""
+
+    def render(self) -> int:
+        return 42
+
+
+# ============================================================================
+# WidgetState Tests
+# ============================================================================
+
+
+def test_widget_state_creation():
+    """Test WidgetState creation with required fields."""
+    state = WidgetState(widget_id="test-1", widget_type="MockTestWidget")
+
+    assert state.widget_id == "test-1"
+    assert state.widget_type == "MockTestWidget"
+    assert state.properties == {}
+    assert state.position is None
+    assert state.size is None
+    assert state.visible is True
+    assert state.enabled is True
+    assert state.parent is None
+    assert state.children == []
+    assert state.callbacks == {}
+    assert state.data_bindings == {}
+
+
+def test_widget_state_with_all_fields():
+    """Test WidgetState creation with all optional fields."""
+    state = WidgetState(
+        widget_id="test-2",
+        widget_type="ButtonWidget",
+        properties={"label": "Click me", "color": "red"},
+        position=(10.0, 20.0),
+        size=(100.0, 50.0),
+        visible=False,
+        enabled=False,
+        parent="parent-1",
+        children=["child-1", "child-2"],
+        callbacks={"click": "on_click"},
+        data_bindings={"value": "model.button_state"},
+    )
+
+    assert state.widget_id == "test-2"
+    assert state.widget_type == "ButtonWidget"
+    assert state.properties == {"label": "Click me", "color": "red"}
+    assert state.position == (10.0, 20.0)
+    assert state.size == (100.0, 50.0)
+    assert state.visible is False
+    assert state.enabled is False
+    assert state.parent == "parent-1"
+    assert state.children == ["child-1", "child-2"]
+    assert state.callbacks == {"click": "on_click"}
+    assert state.data_bindings == {"value": "model.button_state"}
+
+
+def test_widget_state_serialization():
+    """Test WidgetState to_dict serialization."""
+    state = WidgetState(
+        widget_id="test-3",
+        widget_type="SliderWidget",
+        properties={"min": 0, "max": 100, "value": 50},
+        position=(5.0, 10.0),
+        size=(200.0, 30.0),
+    )
+
+    data = state.to_dict()
+
+    assert data["widget_id"] == "test-3"
+    assert data["widget_type"] == "SliderWidget"
+    assert data["properties"] == {"min": 0, "max": 100, "value": 50}
+    assert data["position"] == [5.0, 10.0]  # Converted to list
+    assert data["size"] == [200.0, 30.0]  # Converted to list
+    assert data["visible"] is True
+    assert data["enabled"] is True
+
+
+def test_widget_state_serialization_with_none_values():
+    """Test WidgetState serialization when position/size are None."""
+    state = WidgetState(widget_id="test-4", widget_type="TextWidget")
+
+    data = state.to_dict()
+
+    assert data["position"] is None
+    assert data["size"] is None
+
+
+# ============================================================================
+# Widget ABC Tests
+# ============================================================================
+
+
+def test_widget_abstract_instantiation():
+    """Test that Widget ABC cannot be instantiated directly."""
+    with pytest.raises(TypeError, match="Can't instantiate abstract class"):
+        Widget("test-widget")  # type: ignore
+
+
+def test_widget_concrete_instantiation():
+    """Test concrete widget instantiation."""
+    widget = MockTestWidget("widget-1", label="Test", value=42)
+
+    assert widget.widget_id == "widget-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_id == "widget-1"
+    assert widget.state.widget_type == "MockTestWidget"
+    assert widget.state.properties == {"label": "Test", "value": 42}
+
+
+def test_widget_render_abstract():
+    """Test that render() must be implemented."""
+    widget = MockTestWidget("widget-2")
+    result = widget.render()
+    assert result == "Rendered widget-2"
+    assert widget.render_count == 1
+
+
+def test_widget_update():
+    """Test widget property updates."""
+    widget = MockTestWidget("widget-3", initial="value")
+
+    # Track signal emission
+    signals_received = []
+
+    def on_update(sender, widget):
+        signals_received.append((sender, widget))
+
+    widget_updated.connect(on_update)
+
+    try:
+        # Update properties
+        widget.update(new_prop="new_value", another=123)
+
+        assert widget.state.properties["initial"] == "value"  # Original preserved
+        assert widget.state.properties["new_prop"] == "new_value"
+        assert widget.state.properties["another"] == 123
+
+        # Check signal emitted
+        assert len(signals_received) == 1
+        assert signals_received[0][1] == widget
+    finally:
+        widget_updated.disconnect(on_update)
+
+
+def test_widget_set_visible():
+    """Test widget visibility setter."""
+    widget = MockTestWidget("widget-4")
+
+    assert widget.state.visible is True
+    widget.set_visible(False)
+    assert widget.state.visible is False
+    widget.set_visible(True)
+    assert widget.state.visible is True
+
+
+def test_widget_set_enabled():
+    """Test widget enabled setter."""
+    widget = MockTestWidget("widget-5")
+
+    assert widget.state.enabled is True
+    widget.set_enabled(False)
+    assert widget.state.enabled is False
+    widget.set_enabled(True)
+    assert widget.state.enabled is True
+
+
+def test_widget_set_position():
+    """Test widget position setter."""
+    widget = MockTestWidget("widget-6")
+
+    assert widget.state.position is None
+    widget.set_position(10.0, 20.0)
+    assert widget.state.position == (10.0, 20.0)
+    widget.set_position(100.5, 200.5)
+    assert widget.state.position == (100.5, 200.5)
+
+
+def test_widget_set_size():
+    """Test widget size setter."""
+    widget = MockTestWidget("widget-7")
+
+    assert widget.state.size is None
+    widget.set_size(100.0, 50.0)
+    assert widget.state.size == (100.0, 50.0)
+    widget.set_size(200.0, 100.0)
+    assert widget.state.size == (200.0, 100.0)
+
+
+def test_widget_register_callback():
+    """Test callback registration."""
+    widget = MockTestWidget("widget-8")
+
+    def on_click(event_data):
+        return f"Clicked with {event_data}"
+
+    widget.register_callback("click", on_click)
+
+    assert "click" in widget._callbacks
+    assert widget._callbacks["click"] == on_click
+    assert widget.state.callbacks["click"] == "on_click"
+
+
+def test_widget_trigger_callback():
+    """Test callback triggering."""
+    widget = MockTestWidget("widget-9")
+
+    callback_results = []
+
+    def on_change(value):
+        callback_results.append(value)
+        return value * 2
+
+    widget.register_callback("change", on_change)
+
+    # Trigger callback
+    result = widget.trigger_callback("change", 42)
+    assert result == 84
+    assert callback_results == [42]
+
+    # Trigger with kwargs
+    result = widget.trigger_callback("change", value=10)
+    assert result == 20
+
+
+def test_widget_trigger_nonexistent_callback():
+    """Test triggering callback that doesn't exist."""
+    widget = MockTestWidget("widget-10")
+
+    result = widget.trigger_callback("nonexistent")
+    assert result is None
+
+
+def test_widget_serialize():
+    """Test widget serialization."""
+    widget = MockTestWidget("widget-11", label="Serialize me", value=42)
+    widget.set_position(10.0, 20.0)
+    widget.set_size(100.0, 50.0)
+
+    data = widget.serialize()
+
+    assert data["widget_id"] == "widget-11"
+    assert data["widget_type"] == "MockTestWidget"
+    assert data["properties"] == {"label": "Serialize me", "value": 42}
+    assert data["position"] == [10.0, 20.0]
+    assert data["size"] == [100.0, 50.0]
+
+
+# ============================================================================
+# WidgetFactory Tests
+# ============================================================================
+
+
+def test_widget_factory_creation():
+    """Test WidgetFactory instantiation."""
+    factory = WidgetFactory()
+    assert factory._creators == {}
+    assert factory.list_types() == []
+
+
+def test_widget_factory_register():
+    """Test registering widget types."""
+    factory = WidgetFactory()
+
+    factory.register("test", MockTestWidget)
+    assert "test" in factory._creators
+    assert factory._creators["test"] == MockTestWidget
+
+    factory.register("another", MockAnotherWidget)
+    assert len(factory._creators) == 2
+    assert factory.list_types() == ["test", "another"]
+
+
+def test_widget_factory_create():
+    """Test creating widgets via factory."""
+    factory = WidgetFactory()
+    factory.register("test", MockTestWidget)
+
+    # Track signal emission
+    signals_received = []
+
+    def on_create(sender, widget):
+        signals_received.append((sender, widget))
+
+    widget_created.connect(on_create)
+
+    try:
+        widget = factory.create("test", "widget-12", label="Factory created")
+
+        assert isinstance(widget, MockTestWidget)
+        assert widget.widget_id == "widget-12"
+        assert widget.state.properties["label"] == "Factory created"
+
+        # Check signal emitted
+        assert len(signals_received) == 1
+        assert signals_received[0][1] == widget
+    finally:
+        widget_created.disconnect(on_create)
+
+
+def test_widget_factory_create_unknown_type():
+    """Test creating widget with unregistered type."""
+    factory = WidgetFactory()
+
+    with pytest.raises(ValueError, match="Unknown widget type: unknown"):
+        factory.create("unknown", "widget-13")
+
+
+def test_widget_factory_list_types():
+    """Test listing registered widget types."""
+    factory = WidgetFactory()
+
+    assert factory.list_types() == []
+
+    factory.register("button", MockTestWidget)
+    factory.register("text", MockAnotherWidget)
+
+    types = factory.list_types()
+    assert sorted(types) == ["button", "text"]
+
+
+# ============================================================================
+# WidgetRegistry Tests
+# ============================================================================
+
+
+def test_widget_registry_creation():
+    """Test WidgetRegistry instantiation."""
+    registry = WidgetRegistry()
+
+    assert registry._widgets == {}
+    assert isinstance(registry.factory, WidgetFactory)
+
+
+def test_widget_registry_add():
+    """Test adding widgets to registry."""
+    registry = WidgetRegistry()
+    widget = MockTestWidget("widget-14")
+
+    registry.add(widget)
+
+    assert "widget-14" in registry._widgets
+    assert registry._widgets["widget-14"] == widget
+
+
+def test_widget_registry_get():
+    """Test retrieving widgets from registry."""
+    registry = WidgetRegistry()
+    widget = MockTestWidget("widget-15")
+    registry.add(widget)
+
+    retrieved = registry.get("widget-15")
+    assert retrieved == widget
+    assert retrieved.widget_id == "widget-15"
+
+
+def test_widget_registry_get_nonexistent():
+    """Test retrieving non-existent widget."""
+    registry = WidgetRegistry()
+
+    result = registry.get("nonexistent")
+    assert result is None
+
+
+def test_widget_registry_remove():
+    """Test removing widgets from registry."""
+    registry = WidgetRegistry()
+    widget = MockTestWidget("widget-16")
+    registry.add(widget)
+
+    assert registry.get("widget-16") is not None
+
+    # Remove widget
+    result = registry.remove("widget-16")
+    assert result is True
+    assert registry.get("widget-16") is None
+
+
+def test_widget_registry_remove_nonexistent():
+    """Test removing non-existent widget."""
+    registry = WidgetRegistry()
+
+    result = registry.remove("nonexistent")
+    assert result is False
+
+
+def test_widget_registry_list():
+    """Test listing widget IDs."""
+    registry = WidgetRegistry()
+
+    assert registry.list() == []
+
+    widget1 = MockTestWidget("widget-17")
+    widget2 = MockTestWidget("widget-18")
+    registry.add(widget1)
+    registry.add(widget2)
+
+    widget_ids = registry.list()
+    assert sorted(widget_ids) == ["widget-17", "widget-18"]
+
+
+def test_widget_registry_get_all():
+    """Test getting all widgets."""
+    registry = WidgetRegistry()
+
+    widget1 = MockTestWidget("widget-19")
+    widget2 = MockAnotherWidget("widget-20")
+    registry.add(widget1)
+    registry.add(widget2)
+
+    all_widgets = registry.get_all()
+    assert len(all_widgets) == 2
+    assert all_widgets["widget-19"] == widget1
+    assert all_widgets["widget-20"] == widget2
+
+    # Verify it's a copy
+    all_widgets["new-widget"] = MockTestWidget("widget-21")
+    assert "new-widget" not in registry._widgets
+
+
+def test_widget_registry_clear():
+    """Test clearing all widgets."""
+    registry = WidgetRegistry()
+
+    widget1 = MockTestWidget("widget-22")
+    widget2 = MockTestWidget("widget-23")
+    registry.add(widget1)
+    registry.add(widget2)
+
+    assert len(registry._widgets) == 2
+
+    registry.clear()
+
+    assert len(registry._widgets) == 0
+    assert registry.list() == []
+
+
+def test_widget_registry_factory_integration():
+    """Test full integration of factory with registry."""
+    registry = WidgetRegistry()
+
+    # Register widget type with factory
+    registry.factory.register("test", MockTestWidget)
+
+    # Create widget via factory
+    widget = registry.factory.create("test", "widget-24", label="Integrated")
+
+    # Add to registry
+    registry.add(widget)
+
+    # Retrieve from registry
+    retrieved = registry.get("widget-24")
+    assert retrieved == widget
+    assert retrieved.state.properties["label"] == "Integrated"
+
+
+# ============================================================================
+# Coverage Tests (edge cases)
+# ============================================================================
+
+
+def test_widget_multiple_updates():
+    """Test multiple consecutive updates."""
+    widget = MockTestWidget("widget-25", initial="value")
+
+    widget.update(first="1")
+    widget.update(second="2")
+    widget.update(third="3")
+
+    assert widget.state.properties["initial"] == "value"
+    assert widget.state.properties["first"] == "1"
+    assert widget.state.properties["second"] == "2"
+    assert widget.state.properties["third"] == "3"
+
+
+def test_widget_update_overwrites():
+    """Test that updates overwrite existing properties."""
+    widget = MockTestWidget("widget-26", value=1)
+
+    assert widget.state.properties["value"] == 1
+
+    widget.update(value=2)
+    assert widget.state.properties["value"] == 2
+
+    widget.update(value=3)
+    assert widget.state.properties["value"] == 3
+
+
+def test_widget_registry_replace_widget():
+    """Test replacing widget with same ID."""
+    registry = WidgetRegistry()
+
+    widget1 = MockTestWidget("same-id")
+    widget2 = MockAnotherWidget("same-id")
+
+    registry.add(widget1)
+    assert isinstance(registry.get("same-id"), MockTestWidget)
+
+    registry.add(widget2)
+    assert isinstance(registry.get("same-id"), MockAnotherWidget)
+
+
+def test_widget_state_property_mutation():
+    """Test that properties dict is mutable."""
+    state = WidgetState(widget_id="test", widget_type="MockTestWidget")
+
+    assert state.properties == {}
+
+    state.properties["key1"] = "value1"
+    assert state.properties["key1"] == "value1"
+
+    state.properties["key2"] = "value2"
+    assert len(state.properties) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -197,6 +197,9 @@ dev = [
 dev = [
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
 ]
 
 [package.metadata]
@@ -224,6 +227,9 @@ provides-extras = ["dev", "all"]
 dev = [
     { name = "mypy", specifier = ">=1.18.2" },
     { name = "pre-commit", specifier = ">=4.3.0" },
+    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-asyncio", specifier = ">=1.2.0" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -159,7 +159,7 @@ wheels = [
 
 [[package]]
 name = "champi-imgui"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "blinker" },
@@ -193,6 +193,12 @@ dev = [
     { name = "ruff" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pre-commit" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "blinker", specifier = ">=1.9.0" },
@@ -213,6 +219,12 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
 provides-extras = ["dev", "all"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.18.2" },
+    { name = "pre-commit", specifier = ">=4.3.0" },
+]
 
 [[package]]
 name = "charset-normalizer"
@@ -611,6 +623,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/02/6e639e90f181dc9127046e00d0528f9f7ad12d428972e3a5378b9aefdb0b/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-manylinux_2_28_x86_64.whl", hash = "sha256:7916034efa867927892635733a3b6af8cd95ceb10566fd7f1e0d2763c2ee8b12", size = 243525, upload_time = "2025-09-12T08:54:34.006Z" },
     { url = "https://files.pythonhosted.org/packages/84/06/cb588ca65561defe0fc48d1df4c2ac12569b81231ae4f2b52ab37007d0bd/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-win32.whl", hash = "sha256:6c9549da71b93e367b4d71438798daae1da2592039fd14204a80a1a2348ae127", size = 552685, upload_time = "2025-09-12T08:54:35.723Z" },
     { url = "https://files.pythonhosted.org/packages/86/27/00c9c96af18ac0a5eac2ff61cbe306551a2d770d7173f396d0792ee1a59e/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.p39.p310.p311.p312.p313-none-win_amd64.whl", hash = "sha256:6292d5d6634d668cd23d337e6089491d3945a9aa4ac6e1667b0003520d7caa51", size = 559466, upload_time = "2025-09-12T08:54:37.661Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/87/de0b33f6f00687499ca1371f22aa73396341b85bf88f1a284f9da8842493/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-macosx_10_6_intel.whl", hash = "sha256:2aab89d2d9535635ba011fc7303390685169a1aa6731ad580d08d043524b8899", size = 105326, upload_time = "2026-01-28T05:57:56.083Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/a6/6ea2f73ad4474896d9e38b3ffbe6ffd5a802c738392269e99e8c6621a461/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-macosx_11_0_arm64.whl", hash = "sha256:23936202a107039b5372f0b88ae1d11080746aa1c78910a45d4a0c4cf408cfaa", size = 102180, upload_time = "2026-01-28T05:57:57.787Z" },
+    { url = "https://files.pythonhosted.org/packages/58/19/d81b19e8261b9cb51b81d1402167791fef81088dfe91f0c4e9d136fdc5ca/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-manylinux2014_aarch64.whl", hash = "sha256:7be06d0838f61df67bd54cb6266a6193d54083acb3624ff3c3812a6358406fa4", size = 230038, upload_time = "2026-01-28T05:57:59.105Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/fa/b035636cd82198b97b51a93efe9cfc4343d6b15cefbd336a3f2be871d848/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-manylinux2014_x86_64.whl", hash = "sha256:91d36b3582a766512eff8e3b5dcc2d3ffcbf10b7cf448551085a08a10f1b8244", size = 241983, upload_time = "2026-01-28T05:58:00.352Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b4/f7b6cc022dd7c68b6c702d19da5d591f978f89c958b9bd3090615db0c739/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-manylinux_2_28_aarch64.whl", hash = "sha256:27c9e9a2d5e1dc3c9e3996171d844d9df9a5a101e797cb94cce217b7afcf8fd9", size = 231053, upload_time = "2026-01-28T05:58:01.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/3f/efeb7c6801c46e11bd666a5180f0d615f74f72264212f74f39586c6fda9d/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-manylinux_2_28_x86_64.whl", hash = "sha256:ce6724bb7cb3d0543dcba17206dce909f94176e68220b8eafee72e9f92bcf542", size = 243522, upload_time = "2026-01-28T05:58:03.517Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/b9/b04c3aa0aad2870cfe799f32f8b59789c98e1816bbce9e83f4823c5b840b/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-win32.whl", hash = "sha256:fca724a21a372731edb290841edd28a9fb1ee490f833392752844ac807c0086a", size = 552682, upload_time = "2026-01-28T05:58:05.649Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/e1/6d6816b296a529ac9b897ad228b1e084eb1f92319e96371880eebdc874a6/glfw-2.10.0-py2.py27.py3.py30.py31.py32.py33.py34.py35.py36.py37.py38.py39.py310.py311.py312.py313.py314-none-win_amd64.whl", hash = "sha256:823c0bd7770977d4b10e0ed0aef2f3682276b7c88b8b65cfc540afce5951392f", size = 559464, upload_time = "2026-01-28T05:58:07.261Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a8/d4dab8a58fc2e6981fc7a58c4e56ba9d777fb24931cec6a22152edbb3540/glfw-2.10.0-py2.py3-none-macosx_10_6_intel.whl", hash = "sha256:a0d1f29f206219cc291edfb6cace663a86da2470632551c998e3db82d48ea177", size = 105288, upload_time = "2026-03-10T17:21:19.929Z" },
+    { url = "https://files.pythonhosted.org/packages/14/61/68d35e001872a7705112418da236fa2418d4f2e5419f8b2837f9b81bb3da/glfw-2.10.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:d28d6f3ef217e64e35dc6fd0a7acb4cec9bfe7cd14dd9b35a7228a87002de154", size = 102139, upload_time = "2026-03-10T17:21:21.645Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e1/ca5984081aaae07c9d371cb11dc4e4ff603510678ed9b73e58b6c351fe63/glfw-2.10.0-py2.py3-none-manylinux2014_aarch64.whl", hash = "sha256:f968b522bb6a0e04aaf4dcac30a476d7229308bb2bac406a60587debb5a61e29", size = 229998, upload_time = "2026-03-10T17:21:23.549Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c4/82ac75fdcfba2896da7a573c0fc7f8ceb8f77ead6866d500d06c32f1c464/glfw-2.10.0-py2.py3-none-manylinux2014_x86_64.whl", hash = "sha256:68cf3752bdadb6f4bc0a876247c28c88c7251ac39f8af076ed938fdfd71e72dd", size = 241944, upload_time = "2026-03-10T17:21:26.102Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/96/9f691823cca5eb6a08f346bd0ff03b78032db9370b509a1e9c8976fb20a5/glfw-2.10.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:44d98de5dbf8f727e0cb29f9b29d29528ea7570f2e6f42f8430a69df05f12b48", size = 231009, upload_time = "2026-03-10T17:21:28.481Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/93/977b9e679e356871d428ae7a1139ec767dd5177bed58a6344b4d2199e00f/glfw-2.10.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:cca5158d62189e08792b1ae54f92307a282921a0e7783315b467e21b0a381c88", size = 243480, upload_time = "2026-03-10T17:21:30.538Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bd/cea9569c8f2188b0a104472951420434a3e1f5cf26f5836ef9d7227a1a30/glfw-2.10.0-py2.py3-none-win32.whl", hash = "sha256:5e024509989740e8e7b86cc4aab508195495f79879072b0e1f68bd036a2916ad", size = 552641, upload_time = "2026-03-10T17:21:32.653Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9b/4366ad3e1c0688146c70aa6143584d6a8d88583b9390f106250e25a3d5cd/glfw-2.10.0-py2.py3-none-win_amd64.whl", hash = "sha256:7f787ee8645781f10e8800438ce4357ab38c573ffb191aba380c1e72eba6311c", size = 559423, upload_time = "2026-03-10T17:21:34.766Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Merges `origin/feat/core-widget-system` into main, bringing in the Widget ABC, WidgetFactory, WidgetRegistry, and 4 widget modules (basic, color, input, progress)
- Adds 10 test files covering widget infrastructure and all widget types (248 tests, all passing)
- Updates `pyproject.toml` with dev dependencies (pytest, pytest-asyncio, pytest-cov) and `uv.lock`

## What lands on main
- `src/champi_imgui/core/widget.py` — Widget ABC, WidgetFactory, WidgetRegistry (255 lines)
- `src/champi_imgui/widgets/basic.py` — Button, Text, Checkbox, RadioButton, Combo, ListBox
- `src/champi_imgui/widgets/color.py` — ColorPicker, ColorEdit, ColorButton
- `src/champi_imgui/widgets/input.py` — InputText, InputInt, InputFloat, MultiInput variants
- `src/champi_imgui/widgets/progress.py` — ProgressBar, LoadingIndicator

## Quality gates
- `ruff check src/` — passed
- `ruff format --check src/` — passed
- `mypy src/` — passed (17 source files, no issues)
- `pytest tests/` — 248 passed, 0 failures

Closes #6