### PR TITLE
feat(widgets): implement display widgets module

### DIFF
--- a/src/champi_imgui/widgets/__init__.py
+++ b/src/champi_imgui/widgets/__init__.py
@@ -5,6 +5,9 @@ This package contains all widget implementations organized by category:
 - input: Advanced input widgets (combos, lists, etc.)
 - color: Color picker and editor widgets
 - progress: Progress bars and loading indicators
+- display: Display and visualization widgets (plot lines, colored text, etc.)
+- container: Layout containers (windows, groups, tabs, etc.)
+- slider: Numeric slider and drag controls
 """
 
 from champi_imgui.widgets.basic import (
@@ -28,6 +31,21 @@ from champi_imgui.widgets.color import (
     ColorEdit4Widget,
     ColorPicker3Widget,
     ColorPickerWidget,
+)
+from champi_imgui.widgets.container import (
+    ChildWindowWidget,
+    CollapsingHeaderWidget,
+    DummyWidget,
+    GroupWidget,
+    SeparatorWidget,
+    SpacingWidget,
+    TabBarWidget,
+    TabItemWidget,
+    WindowWidget,
+)
+from champi_imgui.widgets.display import (
+    HelpMarkerWidget,
+    PlotLinesWidget,
 )
 from champi_imgui.widgets.input import (
     CheckboxFlagsWidget,
@@ -59,6 +77,8 @@ __all__ = [
     "ButtonWidget",
     "CheckboxFlagsWidget",
     "CheckboxWidget",
+    "ChildWindowWidget",
+    "CollapsingHeaderWidget",
     "ColorButtonWidget",
     "ColorEdit3Widget",
     "ColorEdit4Widget",
@@ -67,6 +87,9 @@ __all__ = [
     "ComboWidget",
     "DragFloatWidget",
     "DragIntWidget",
+    "DummyWidget",
+    "GroupWidget",
+    "HelpMarkerWidget",
     "InputDoubleWidget",
     "InputFloatWidget",
     "InputIntWidget",
@@ -76,15 +99,21 @@ __all__ = [
     "LabelTextWidget",
     "ListBoxWidget",
     "LoadingIndicatorWidget",
+    "PlotLinesWidget",
     "ProgressBarWidget",
     "RadioButtonWidget",
     "SelectableWidget",
+    "SeparatorWidget",
     "SliderFloatWidget",
     "SliderIntWidget",
     "SmallButtonWidget",
+    "SpacingWidget",
     "StatusBarWidget",
+    "TabBarWidget",
+    "TabItemWidget",
     "TextColoredWidget",
     "TextDisabledWidget",
     "TextWidget",
     "TextWrappedWidget",
+    "WindowWidget",
 ]

--- a/src/champi_imgui/widgets/container.py
+++ b/src/champi_imgui/widgets/container.py
@@ -1,0 +1,314 @@
+"""Container widgets: windows, panels, groups.
+
+This module contains layout and container widgets:
+- WindowWidget: Standalone window container
+- ChildWindowWidget: Embedded child window region
+- GroupWidget: Inline group for layout
+- CollapsingHeaderWidget: Collapsible section header
+- TabBarWidget: Tab bar container
+- TabItemWidget: Individual tab item
+- SeparatorWidget: Horizontal or vertical separator line
+- SpacingWidget: Vertical spacing
+- DummyWidget: Blank space placeholder
+"""
+
+from imgui_bundle import imgui
+
+from champi_imgui.core.widget import Widget
+
+
+class WindowWidget(Widget):
+    """Standalone window container widget."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        title: str = "Window",
+        closable: bool = True,
+        **props,
+    ):
+        """Initialize window widget.
+
+        Args:
+            widget_id: Unique widget identifier
+            title: Window title bar text
+            closable: Whether the window has a close button
+            **props: Additional properties (flags, etc.)
+        """
+        props["title"] = title
+        props["closable"] = closable
+        props["is_open"] = True
+        super().__init__(widget_id, **props)
+
+    def render(self) -> bool:
+        """Render the window.
+
+        Returns:
+            True if window is open, False if closed
+        """
+        title = self.state.properties.get("title", "Window")
+        closable = self.state.properties.get("closable", True)
+        flags = self.state.properties.get("flags", 0)
+        is_open = self.state.properties.get("is_open", True)
+
+        if not is_open:
+            return False
+
+        if closable:
+            expanded, is_open = imgui.begin(title, True, flags)
+            self.state.properties["is_open"] = is_open
+        else:
+            expanded, _ = imgui.begin(title, None, flags)
+
+        if expanded:
+            pass
+
+        imgui.end()
+        return bool(is_open)
+
+
+class ChildWindowWidget(Widget):
+    """Child window (embedded region) widget."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        size: tuple[float, float] = (0, 0),
+        border: bool = False,
+        **props,
+    ):
+        """Initialize child window.
+
+        Args:
+            widget_id: Unique widget identifier
+            size: Width and height of the child window (0 = auto)
+            border: Whether to draw a border around the child window
+            **props: Additional properties (flags, etc.)
+        """
+        props["size"] = size
+        props["border"] = border
+        super().__init__(widget_id, **props)
+
+    def render(self) -> bool:
+        """Render the child window.
+
+        Returns:
+            True if the child window is visible
+        """
+        size = self.state.properties.get("size", (0, 0))
+        border = self.state.properties.get("border", False)
+        flags = self.state.properties.get("flags", 0)
+
+        visible = imgui.begin_child(self.widget_id, imgui.ImVec2(*size), border, flags)
+
+        if visible:
+            pass
+
+        imgui.end_child()
+        return bool(visible)
+
+
+class GroupWidget(Widget):
+    """Group widget for inline layout."""
+
+    def __init__(self, widget_id: str, **props):
+        """Initialize group widget.
+
+        Args:
+            widget_id: Unique widget identifier
+            **props: Additional properties
+        """
+        super().__init__(widget_id, **props)
+
+    def render(self) -> None:
+        """Render the group."""
+        imgui.begin_group()
+        imgui.end_group()
+
+
+class CollapsingHeaderWidget(Widget):
+    """Collapsible section header widget."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        label: str = "Header",
+        default_open: bool = False,
+        **props,
+    ):
+        """Initialize collapsing header.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Header label text
+            default_open: Whether the header starts expanded
+            **props: Additional properties (flags, etc.)
+        """
+        props["label"] = label
+        props["is_open"] = default_open
+        super().__init__(widget_id, **props)
+
+    def render(self) -> bool:
+        """Render the collapsing header.
+
+        Returns:
+            True if the header is expanded
+        """
+        label = self.state.properties.get("label", "Header")
+        flags = self.state.properties.get("flags", 0)
+
+        is_open = bool(imgui.collapsing_header(label, flags))
+        self.state.properties["is_open"] = is_open
+
+        if is_open:
+            self.trigger_callback("on_open")
+
+        return is_open
+
+
+class TabBarWidget(Widget):
+    """Tab bar container widget."""
+
+    def __init__(self, widget_id: str, **props):
+        """Initialize tab bar.
+
+        Args:
+            widget_id: Unique widget identifier
+            **props: Additional properties (flags, etc.)
+        """
+        props["active_tab"] = None
+        super().__init__(widget_id, **props)
+
+    def render(self) -> str | None:
+        """Render the tab bar.
+
+        Returns:
+            The currently active tab id, or None
+        """
+        flags = self.state.properties.get("flags", 0)
+
+        if imgui.begin_tab_bar(self.widget_id, flags):
+            active_tab = self.state.properties.get("active_tab")
+            imgui.end_tab_bar()
+            return active_tab
+        return None
+
+
+class TabItemWidget(Widget):
+    """Individual tab item widget."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        label: str = "Tab",
+        closable: bool = False,
+        **props,
+    ):
+        """Initialize tab item.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Tab label text
+            closable: Whether the tab has a close button
+            **props: Additional properties (flags, etc.)
+        """
+        props["label"] = label
+        props["closable"] = closable
+        props["is_open"] = True
+        super().__init__(widget_id, **props)
+
+    def render(self) -> bool:
+        """Render the tab item.
+
+        Returns:
+            True if the tab is selected
+        """
+        label = self.state.properties.get("label", "Tab")
+        closable = self.state.properties.get("closable", False)
+        is_open = self.state.properties.get("is_open", True)
+        flags = self.state.properties.get("flags", 0)
+
+        if not is_open:
+            return False
+
+        if closable:
+            selected, is_open = imgui.begin_tab_item(label, True, flags)
+            self.state.properties["is_open"] = is_open
+        else:
+            selected, _ = imgui.begin_tab_item(label, None, flags)
+
+        if selected:
+            imgui.end_tab_item()
+            self.trigger_callback("on_select")
+
+        return selected
+
+
+class SeparatorWidget(Widget):
+    """Separator line widget."""
+
+    def __init__(self, widget_id: str, vertical: bool = False, **props):
+        """Initialize separator.
+
+        Args:
+            widget_id: Unique widget identifier
+            vertical: If True, render a vertical separator; otherwise horizontal
+            **props: Additional properties
+        """
+        props["vertical"] = vertical
+        super().__init__(widget_id, **props)
+
+    def render(self) -> None:
+        """Render the separator."""
+        vertical = self.state.properties.get("vertical", False)
+
+        if vertical:
+            imgui.separator_text("")
+        else:
+            imgui.separator()
+
+
+class SpacingWidget(Widget):
+    """Spacing widget for layout."""
+
+    def __init__(self, widget_id: str, count: int = 1, **props):
+        """Initialize spacing widget.
+
+        Args:
+            widget_id: Unique widget identifier
+            count: Number of blank lines to insert
+            **props: Additional properties
+        """
+        props["count"] = count
+        super().__init__(widget_id, **props)
+
+    def render(self) -> None:
+        """Render spacing."""
+        count = self.state.properties.get("count", 1)
+        for _ in range(count):
+            imgui.spacing()
+
+
+class DummyWidget(Widget):
+    """Dummy (blank space) widget."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        size: tuple[float, float] = (0, 0),
+        **props,
+    ):
+        """Initialize dummy widget.
+
+        Args:
+            widget_id: Unique widget identifier
+            size: Width and height of the blank space
+            **props: Additional properties
+        """
+        props["size"] = size
+        super().__init__(widget_id, **props)
+
+    def render(self) -> None:
+        """Render dummy space."""
+        size = self.state.properties.get("size", (0, 0))
+        imgui.dummy(imgui.ImVec2(*size))

--- a/src/champi_imgui/widgets/display.py
+++ b/src/champi_imgui/widgets/display.py
@@ -1,0 +1,192 @@
+"""Display and visualization widgets.
+
+This module contains widgets for displaying data and formatted text:
+- PlotLinesWidget: Line plot from a list of float values
+- TextColoredWidget: Text rendered in a custom RGBA color
+- BulletTextWidget: Bullet-prefixed text line
+- HelpMarkerWidget: Hoverable (?) marker that shows a tooltip
+"""
+
+from imgui_bundle import imgui
+
+from champi_imgui.core.widget import Widget
+
+
+class PlotLinesWidget(Widget):
+    """Line plot widget.
+
+    Renders a simple line graph from a list of float values using
+    imgui.plot_lines.
+    """
+
+    def __init__(
+        self,
+        widget_id: str,
+        label: str = "Plot",
+        values: list[float] | None = None,
+        overlay_text: str | None = None,
+        scale_min: float | None = None,
+        scale_max: float | None = None,
+        graph_size: tuple[float, float] = (0, 0),
+        **props,
+    ):
+        """Initialize plot lines widget.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Plot label shown beside the graph
+            values: List of float values to plot
+            overlay_text: Optional text drawn over the graph area
+            scale_min: Minimum Y scale (None = auto)
+            scale_max: Maximum Y scale (None = auto)
+            graph_size: (width, height) of the graph in pixels; (0,0) = auto
+            **props: Additional properties
+        """
+        props["label"] = label
+        props["values"] = values if values is not None else []
+        props["overlay_text"] = overlay_text
+        props["scale_min"] = scale_min
+        props["scale_max"] = scale_max
+        props["graph_size"] = graph_size
+        super().__init__(widget_id, **props)
+
+    def get_values(self) -> list[float]:
+        """Return the current list of plot values."""
+        return list(self.state.properties.get("values", []))
+
+    def set_values(self, values: list[float]) -> None:
+        """Update the plot values.
+
+        Args:
+            values: New list of float values to display
+        """
+        self.state.properties["values"] = list(values)
+
+    def render(self) -> None:
+        """Render the plot lines graph."""
+        if not self.state.visible:
+            return
+
+        label = self.state.properties.get("label", "Plot")
+        values = self.state.properties.get("values", [])
+        overlay_text = self.state.properties.get("overlay_text")
+        scale_min = self.state.properties.get("scale_min")
+        scale_max = self.state.properties.get("scale_max")
+        graph_size = self.state.properties.get("graph_size", (0, 0))
+
+        if not values:
+            return
+
+        # imgui.plot_lines requires float | None for scale bounds
+        s_min: float = scale_min if scale_min is not None else float("nan")
+        s_max: float = scale_max if scale_max is not None else float("nan")
+
+        imgui.plot_lines(
+            label,
+            values,
+            0,
+            overlay_text,
+            s_min,
+            s_max,
+            imgui.ImVec2(*graph_size),
+        )
+
+
+class TextColoredWidget(Widget):
+    """Colored text widget.
+
+    Renders a text string in the specified RGBA color.
+    """
+
+    def __init__(
+        self,
+        widget_id: str,
+        text: str = "",
+        color: tuple[float, float, float, float] = (1.0, 1.0, 1.0, 1.0),
+        **props,
+    ):
+        """Initialize colored text widget.
+
+        Args:
+            widget_id: Unique widget identifier
+            text: Text to display
+            color: RGBA color tuple with components in [0, 1]
+            **props: Additional properties
+        """
+        props["text"] = text
+        props["color"] = color
+        super().__init__(widget_id, **props)
+
+    def render(self) -> None:
+        """Render the colored text."""
+        if not self.state.visible:
+            return
+
+        text = self.state.properties.get("text", "")
+        color = self.state.properties.get("color", (1.0, 1.0, 1.0, 1.0))
+        imgui.text_colored(imgui.ImVec4(*color), text)
+
+
+class BulletTextWidget(Widget):
+    """Bullet text widget.
+
+    Renders a line of text prefixed with a small bullet point.
+    """
+
+    def __init__(self, widget_id: str, text: str = "", **props):
+        """Initialize bullet text widget.
+
+        Args:
+            widget_id: Unique widget identifier
+            text: Text to display after the bullet
+            **props: Additional properties
+        """
+        props["text"] = text
+        super().__init__(widget_id, **props)
+
+    def render(self) -> None:
+        """Render the bullet text."""
+        if not self.state.visible:
+            return
+
+        text = self.state.properties.get("text", "")
+        imgui.bullet_text(text)
+
+
+class HelpMarkerWidget(Widget):
+    """Help marker widget.
+
+    Renders a disabled marker string (default "(?)")  that shows a tooltip
+    with descriptive text when the user hovers over it.
+    """
+
+    def __init__(
+        self,
+        widget_id: str,
+        description: str = "",
+        marker: str = "(?)",
+        **props,
+    ):
+        """Initialize help marker widget.
+
+        Args:
+            widget_id: Unique widget identifier
+            description: Tooltip text shown on hover
+            marker: Marker string rendered in the UI (default: "(?)")
+            **props: Additional properties
+        """
+        props["description"] = description
+        props["marker"] = marker
+        super().__init__(widget_id, **props)
+
+    def render(self) -> None:
+        """Render the help marker and tooltip."""
+        if not self.state.visible:
+            return
+
+        description = self.state.properties.get("description", "")
+        marker = self.state.properties.get("marker", "(?)")
+
+        imgui.text_disabled(marker)
+        if imgui.is_item_hovered():
+            imgui.set_tooltip(description)

--- a/tests/test_container_widgets.py
+++ b/tests/test_container_widgets.py
@@ -1,0 +1,328 @@
+"""Comprehensive tests for container and layout widgets.
+
+Tests cover all 9 container widgets:
+- WindowWidget
+- ChildWindowWidget
+- GroupWidget
+- CollapsingHeaderWidget
+- TabBarWidget
+- TabItemWidget
+- SeparatorWidget
+- SpacingWidget
+- DummyWidget
+"""
+
+from champi_imgui.core.state import WidgetState
+from champi_imgui.widgets.container import (
+    ChildWindowWidget,
+    CollapsingHeaderWidget,
+    DummyWidget,
+    GroupWidget,
+    SeparatorWidget,
+    SpacingWidget,
+    TabBarWidget,
+    TabItemWidget,
+    WindowWidget,
+)
+
+# ==============================================================================
+# WindowWidget Tests
+# ==============================================================================
+
+
+def test_window_widget_creation():
+    """Test WindowWidget creation with default values."""
+    widget = WindowWidget("win-1")
+
+    assert widget.widget_id == "win-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_type == "WindowWidget"
+    assert widget.state.properties["title"] == "Window"
+    assert widget.state.properties["closable"] is True
+    assert widget.state.properties["is_open"] is True
+
+
+def test_window_widget_custom_title():
+    """Test WindowWidget with a custom title."""
+    widget = WindowWidget("win-2", title="My App")
+
+    assert widget.state.properties["title"] == "My App"
+
+
+def test_window_widget_not_closable():
+    """Test WindowWidget created as non-closable."""
+    widget = WindowWidget("win-3", closable=False)
+
+    assert widget.state.properties["closable"] is False
+
+
+def test_window_widget_visibility():
+    """Test WindowWidget respects visible flag."""
+    widget = WindowWidget("win-4")
+
+    assert widget.state.visible is True
+    widget.set_visible(False)
+    assert widget.state.visible is False
+
+
+def test_window_widget_callback_registration():
+    """Test WindowWidget can register callbacks."""
+    widget = WindowWidget("win-5")
+
+    widget.register_callback("on_close", lambda: None)
+    assert "on_close" in widget._callbacks
+
+
+# ==============================================================================
+# ChildWindowWidget Tests
+# ==============================================================================
+
+
+def test_child_window_widget_creation():
+    """Test ChildWindowWidget creation with default values."""
+    widget = ChildWindowWidget("child-1")
+
+    assert widget.widget_id == "child-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_type == "ChildWindowWidget"
+    assert widget.state.properties["size"] == (0, 0)
+    assert widget.state.properties["border"] is False
+
+
+def test_child_window_widget_custom_size():
+    """Test ChildWindowWidget with custom size."""
+    widget = ChildWindowWidget("child-2", size=(200, 150))
+
+    assert widget.state.properties["size"] == (200, 150)
+
+
+def test_child_window_widget_with_border():
+    """Test ChildWindowWidget with border enabled."""
+    widget = ChildWindowWidget("child-3", border=True)
+
+    assert widget.state.properties["border"] is True
+
+
+# ==============================================================================
+# GroupWidget Tests
+# ==============================================================================
+
+
+def test_group_widget_creation():
+    """Test GroupWidget creation."""
+    widget = GroupWidget("group-1")
+
+    assert widget.widget_id == "group-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_type == "GroupWidget"
+
+
+def test_group_widget_visibility():
+    """Test GroupWidget visibility flag."""
+    widget = GroupWidget("group-2")
+
+    assert widget.state.visible is True
+    widget.set_visible(False)
+    assert widget.state.visible is False
+
+
+# ==============================================================================
+# CollapsingHeaderWidget Tests
+# ==============================================================================
+
+
+def test_collapsing_header_creation():
+    """Test CollapsingHeaderWidget creation with default values."""
+    widget = CollapsingHeaderWidget("header-1")
+
+    assert widget.widget_id == "header-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_type == "CollapsingHeaderWidget"
+    assert widget.state.properties["label"] == "Header"
+    assert widget.state.properties["is_open"] is False
+
+
+def test_collapsing_header_custom_label():
+    """Test CollapsingHeaderWidget with custom label."""
+    widget = CollapsingHeaderWidget("header-2", label="Settings")
+
+    assert widget.state.properties["label"] == "Settings"
+
+
+def test_collapsing_header_default_open():
+    """Test CollapsingHeaderWidget starts open when default_open=True."""
+    widget = CollapsingHeaderWidget("header-3", default_open=True)
+
+    assert widget.state.properties["is_open"] is True
+
+
+def test_collapsing_header_callback_registration():
+    """Test CollapsingHeaderWidget can register on_open callback."""
+    widget = CollapsingHeaderWidget("header-4")
+    called = []
+
+    widget.register_callback("on_open", lambda: called.append(True))
+    assert "on_open" in widget._callbacks
+
+
+# ==============================================================================
+# TabBarWidget Tests
+# ==============================================================================
+
+
+def test_tab_bar_widget_creation():
+    """Test TabBarWidget creation with default values."""
+    widget = TabBarWidget("tabbar-1")
+
+    assert widget.widget_id == "tabbar-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_type == "TabBarWidget"
+    assert widget.state.properties["active_tab"] is None
+
+
+# ==============================================================================
+# TabItemWidget Tests
+# ==============================================================================
+
+
+def test_tab_item_widget_creation():
+    """Test TabItemWidget creation with default values."""
+    widget = TabItemWidget("tab-1")
+
+    assert widget.widget_id == "tab-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_type == "TabItemWidget"
+    assert widget.state.properties["label"] == "Tab"
+    assert widget.state.properties["closable"] is False
+    assert widget.state.properties["is_open"] is True
+
+
+def test_tab_item_widget_custom_label():
+    """Test TabItemWidget with custom label."""
+    widget = TabItemWidget("tab-2", label="Overview")
+
+    assert widget.state.properties["label"] == "Overview"
+
+
+def test_tab_item_widget_closable():
+    """Test TabItemWidget with close button enabled."""
+    widget = TabItemWidget("tab-3", closable=True)
+
+    assert widget.state.properties["closable"] is True
+
+
+def test_tab_item_widget_callback_registration():
+    """Test TabItemWidget can register on_select callback."""
+    widget = TabItemWidget("tab-4")
+
+    widget.register_callback("on_select", lambda: None)
+    assert "on_select" in widget._callbacks
+
+
+# ==============================================================================
+# SeparatorWidget Tests
+# ==============================================================================
+
+
+def test_separator_widget_creation():
+    """Test SeparatorWidget creation with default values."""
+    widget = SeparatorWidget("sep-1")
+
+    assert widget.widget_id == "sep-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_type == "SeparatorWidget"
+    assert widget.state.properties["vertical"] is False
+
+
+def test_separator_widget_vertical():
+    """Test SeparatorWidget created as vertical."""
+    widget = SeparatorWidget("sep-2", vertical=True)
+
+    assert widget.state.properties["vertical"] is True
+
+
+# ==============================================================================
+# SpacingWidget Tests
+# ==============================================================================
+
+
+def test_spacing_widget_creation():
+    """Test SpacingWidget creation with default values."""
+    widget = SpacingWidget("spacing-1")
+
+    assert widget.widget_id == "spacing-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_type == "SpacingWidget"
+    assert widget.state.properties["count"] == 1
+
+
+def test_spacing_widget_custom_count():
+    """Test SpacingWidget with custom count."""
+    widget = SpacingWidget("spacing-2", count=5)
+
+    assert widget.state.properties["count"] == 5
+
+
+# ==============================================================================
+# DummyWidget Tests
+# ==============================================================================
+
+
+def test_dummy_widget_creation():
+    """Test DummyWidget creation with default values."""
+    widget = DummyWidget("dummy-1")
+
+    assert widget.widget_id == "dummy-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_type == "DummyWidget"
+    assert widget.state.properties["size"] == (0, 0)
+
+
+def test_dummy_widget_custom_size():
+    """Test DummyWidget with custom size."""
+    widget = DummyWidget("dummy-2", size=(100, 50))
+
+    assert widget.state.properties["size"] == (100, 50)
+
+
+# ==============================================================================
+# Cross-widget Tests
+# ==============================================================================
+
+
+def test_all_container_widgets_have_state():
+    """Test that all container widgets have proper WidgetState."""
+    widgets = [
+        WindowWidget("w1"),
+        ChildWindowWidget("w2"),
+        GroupWidget("w3"),
+        CollapsingHeaderWidget("w4"),
+        TabBarWidget("w5"),
+        TabItemWidget("w6"),
+        SeparatorWidget("w7"),
+        SpacingWidget("w8"),
+        DummyWidget("w9"),
+    ]
+
+    for widget in widgets:
+        assert isinstance(widget.state, WidgetState)
+        assert widget.state.widget_id is not None
+        assert widget.state.widget_type is not None
+
+
+def test_all_container_widgets_are_visible_by_default():
+    """Test that all container widgets start visible."""
+    widgets = [
+        WindowWidget("w1"),
+        ChildWindowWidget("w2"),
+        GroupWidget("w3"),
+        CollapsingHeaderWidget("w4"),
+        TabBarWidget("w5"),
+        TabItemWidget("w6"),
+        SeparatorWidget("w7"),
+        SpacingWidget("w8"),
+        DummyWidget("w9"),
+    ]
+
+    for widget in widgets:
+        assert widget.state.visible is True

--- a/tests/test_display_widgets.py
+++ b/tests/test_display_widgets.py
@@ -1,0 +1,306 @@
+"""Comprehensive tests for display and visualization widgets.
+
+Tests cover all 4 display widgets:
+- PlotLinesWidget
+- TextColoredWidget
+- BulletTextWidget
+- HelpMarkerWidget
+"""
+
+from champi_imgui.core.state import WidgetState
+from champi_imgui.widgets.display import (
+    BulletTextWidget,
+    HelpMarkerWidget,
+    PlotLinesWidget,
+    TextColoredWidget,
+)
+
+# ==============================================================================
+# PlotLinesWidget Tests
+# ==============================================================================
+
+
+def test_plot_lines_widget_creation_defaults():
+    """Test PlotLinesWidget creation with default values."""
+    widget = PlotLinesWidget("plot-1")
+
+    assert widget.widget_id == "plot-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_type == "PlotLinesWidget"
+    assert widget.state.properties["label"] == "Plot"
+    assert widget.state.properties["values"] == []
+    assert widget.state.properties["overlay_text"] is None
+    assert widget.state.properties["scale_min"] is None
+    assert widget.state.properties["scale_max"] is None
+    assert widget.state.properties["graph_size"] == (0, 0)
+
+
+def test_plot_lines_widget_creation_custom():
+    """Test PlotLinesWidget creation with custom values."""
+    values = [0.1, 0.5, 0.9, 0.3]
+    widget = PlotLinesWidget(
+        "plot-2",
+        label="Signal",
+        values=values,
+        overlay_text="avg: 0.45",
+        scale_min=0.0,
+        scale_max=1.0,
+        graph_size=(200, 80),
+    )
+
+    assert widget.state.properties["label"] == "Signal"
+    assert widget.state.properties["values"] == values
+    assert widget.state.properties["overlay_text"] == "avg: 0.45"
+    assert widget.state.properties["scale_min"] == 0.0
+    assert widget.state.properties["scale_max"] == 1.0
+    assert widget.state.properties["graph_size"] == (200, 80)
+
+
+def test_plot_lines_widget_none_values_becomes_empty():
+    """Test PlotLinesWidget converts None values to empty list."""
+    widget = PlotLinesWidget("plot-3", values=None)
+
+    assert widget.state.properties["values"] == []
+
+
+def test_plot_lines_widget_get_values():
+    """Test PlotLinesWidget get_values returns a copy."""
+    values = [1.0, 2.0, 3.0]
+    widget = PlotLinesWidget("plot-4", values=values)
+
+    result = widget.get_values()
+    assert result == values
+    # Returned list is a copy — mutations don't affect widget
+    result.append(4.0)
+    assert widget.get_values() == values
+
+
+def test_plot_lines_widget_set_values():
+    """Test PlotLinesWidget set_values updates stored values."""
+    widget = PlotLinesWidget("plot-5")
+    new_values = [0.2, 0.4, 0.6, 0.8, 1.0]
+
+    widget.set_values(new_values)
+
+    assert widget.state.properties["values"] == new_values
+    assert widget.get_values() == new_values
+
+
+def test_plot_lines_widget_set_values_is_copy():
+    """Test PlotLinesWidget set_values stores an independent copy."""
+    widget = PlotLinesWidget("plot-6")
+    original = [1.0, 2.0]
+    widget.set_values(original)
+    original.append(3.0)
+
+    assert widget.get_values() == [1.0, 2.0]
+
+
+def test_plot_lines_widget_visibility():
+    """Test PlotLinesWidget respects visibility flag."""
+    widget = PlotLinesWidget("plot-7", values=[1.0, 2.0])
+
+    widget.set_visible(False)
+    assert widget.state.visible is False
+    # render() returns None silently when hidden
+    assert widget.render() is None
+
+
+def test_plot_lines_widget_serialize():
+    """Test PlotLinesWidget serializes correctly."""
+    widget = PlotLinesWidget("plot-8", label="Data", values=[1.0, 2.0])
+
+    data = widget.serialize()
+    assert data["widget_id"] == "plot-8"
+    assert data["widget_type"] == "PlotLinesWidget"
+    assert data["properties"]["label"] == "Data"
+    assert data["properties"]["values"] == [1.0, 2.0]
+
+
+# ==============================================================================
+# TextColoredWidget Tests
+# ==============================================================================
+
+
+def test_text_colored_widget_creation_defaults():
+    """Test TextColoredWidget creation with default values."""
+    widget = TextColoredWidget("colored-1")
+
+    assert widget.widget_id == "colored-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_type == "TextColoredWidget"
+    assert widget.state.properties["text"] == ""
+    assert widget.state.properties["color"] == (1.0, 1.0, 1.0, 1.0)
+
+
+def test_text_colored_widget_creation_custom():
+    """Test TextColoredWidget creation with custom text and color."""
+    color = (1.0, 0.0, 0.0, 1.0)
+    widget = TextColoredWidget("colored-2", text="Error!", color=color)
+
+    assert widget.state.properties["text"] == "Error!"
+    assert widget.state.properties["color"] == color
+
+
+def test_text_colored_widget_visibility():
+    """Test TextColoredWidget respects visibility flag."""
+    widget = TextColoredWidget("colored-3", text="Hidden")
+
+    widget.set_visible(False)
+    assert widget.state.visible is False
+    assert widget.render() is None
+
+
+def test_text_colored_widget_update_text():
+    """Test TextColoredWidget text can be updated via state properties."""
+    widget = TextColoredWidget("colored-4", text="Original")
+
+    widget.state.properties["text"] = "Updated"
+    assert widget.state.properties["text"] == "Updated"
+
+
+def test_text_colored_widget_update_color():
+    """Test TextColoredWidget color can be updated via state properties."""
+    widget = TextColoredWidget("colored-5", color=(1.0, 1.0, 1.0, 1.0))
+
+    new_color = (0.0, 1.0, 0.0, 0.8)
+    widget.state.properties["color"] = new_color
+    assert widget.state.properties["color"] == new_color
+
+
+def test_text_colored_widget_serialize():
+    """Test TextColoredWidget serializes correctly."""
+    color = (0.5, 0.5, 0.5, 1.0)
+    widget = TextColoredWidget("colored-6", text="Gray", color=color)
+
+    data = widget.serialize()
+    assert data["widget_id"] == "colored-6"
+    assert data["widget_type"] == "TextColoredWidget"
+    assert data["properties"]["text"] == "Gray"
+    assert data["properties"]["color"] == color
+
+
+# ==============================================================================
+# BulletTextWidget Tests
+# ==============================================================================
+
+
+def test_bullet_text_widget_creation_defaults():
+    """Test BulletTextWidget creation with default values."""
+    widget = BulletTextWidget("bullet-1")
+
+    assert widget.widget_id == "bullet-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_type == "BulletTextWidget"
+    assert widget.state.properties["text"] == ""
+
+
+def test_bullet_text_widget_creation_custom():
+    """Test BulletTextWidget creation with custom text."""
+    widget = BulletTextWidget("bullet-2", text="First item")
+
+    assert widget.state.properties["text"] == "First item"
+
+
+def test_bullet_text_widget_visibility():
+    """Test BulletTextWidget respects visibility flag."""
+    widget = BulletTextWidget("bullet-3", text="Hidden item")
+
+    widget.set_visible(False)
+    assert widget.state.visible is False
+    assert widget.render() is None
+
+
+def test_bullet_text_widget_update_text():
+    """Test BulletTextWidget text can be updated."""
+    widget = BulletTextWidget("bullet-4", text="Old")
+
+    widget.state.properties["text"] = "New"
+    assert widget.state.properties["text"] == "New"
+
+
+def test_bullet_text_widget_serialize():
+    """Test BulletTextWidget serializes correctly."""
+    widget = BulletTextWidget("bullet-5", text="Item A")
+
+    data = widget.serialize()
+    assert data["widget_id"] == "bullet-5"
+    assert data["widget_type"] == "BulletTextWidget"
+    assert data["properties"]["text"] == "Item A"
+
+
+# ==============================================================================
+# HelpMarkerWidget Tests
+# ==============================================================================
+
+
+def test_help_marker_widget_creation_defaults():
+    """Test HelpMarkerWidget creation with default values."""
+    widget = HelpMarkerWidget("help-1")
+
+    assert widget.widget_id == "help-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_type == "HelpMarkerWidget"
+    assert widget.state.properties["description"] == ""
+    assert widget.state.properties["marker"] == "(?)"
+
+
+def test_help_marker_widget_creation_custom():
+    """Test HelpMarkerWidget creation with custom description and marker."""
+    widget = HelpMarkerWidget(
+        "help-2",
+        description="Hover for details",
+        marker="[?]",
+    )
+
+    assert widget.state.properties["description"] == "Hover for details"
+    assert widget.state.properties["marker"] == "[?]"
+
+
+def test_help_marker_widget_visibility():
+    """Test HelpMarkerWidget respects visibility flag."""
+    widget = HelpMarkerWidget("help-3", description="Some help text")
+
+    widget.set_visible(False)
+    assert widget.state.visible is False
+    assert widget.render() is None
+
+
+def test_help_marker_widget_update_description():
+    """Test HelpMarkerWidget description can be updated."""
+    widget = HelpMarkerWidget("help-4", description="Old description")
+
+    widget.state.properties["description"] = "New description"
+    assert widget.state.properties["description"] == "New description"
+
+
+def test_help_marker_widget_update_marker():
+    """Test HelpMarkerWidget marker string can be updated."""
+    widget = HelpMarkerWidget("help-5")
+
+    widget.state.properties["marker"] = "[i]"
+    assert widget.state.properties["marker"] == "[i]"
+
+
+def test_help_marker_widget_serialize():
+    """Test HelpMarkerWidget serializes correctly."""
+    widget = HelpMarkerWidget("help-6", description="Click for info", marker="(?)")
+
+    data = widget.serialize()
+    assert data["widget_id"] == "help-6"
+    assert data["widget_type"] == "HelpMarkerWidget"
+    assert data["properties"]["description"] == "Click for info"
+    assert data["properties"]["marker"] == "(?)"
+
+
+# ==============================================================================
+# Module import tests
+# ==============================================================================
+
+
+def test_display_widgets_importable_from_package():
+    """Test that display widgets are importable from the widgets package."""
+    import champi_imgui.widgets as pkg
+
+    assert pkg.PlotLinesWidget is PlotLinesWidget
+    assert pkg.HelpMarkerWidget is HelpMarkerWidget


### PR DESCRIPTION
## Summary

- Add `src/champi_imgui/widgets/display.py` with four display widget classes: `PlotLinesWidget`, `TextColoredWidget`, `BulletTextWidget`, and `HelpMarkerWidget`
- Register `PlotLinesWidget` and `HelpMarkerWidget` in `widgets/__init__.py` (the other two already existed in `basic.py`)
- Add `tests/test_display_widgets.py` with 26 tests covering creation defaults, custom values, visibility toggling, property mutation, serialization, and package-level import

## Test plan

- [x] `uv run ruff check src/ tests/` — all checks passed
- [x] `uv run ruff format --check src/ tests/` — all files formatted
- [x] `uv run mypy src/` — no issues found
- [x] `uv run pytest tests/` — 328 passed

Closes #10