### PR TITLE
feat(widgets): implement plotting widgets module via ImPlot

### DIFF
--- a/src/champi_imgui/widgets/__init__.py
+++ b/src/champi_imgui/widgets/__init__.py
@@ -8,6 +8,8 @@ This package contains all widget implementations organized by category:
 - display: Display and visualization widgets (plot lines, colored text, etc.)
 - container: Layout containers (windows, groups, tabs, etc.)
 - slider: Numeric slider and drag controls
+- menu: Menu and navigation widgets (menu bar, menus, tree nodes, etc.)
+- plotting: Advanced plotting widgets using ImPlot
 """
 
 from champi_imgui.widgets.basic import (
@@ -58,6 +60,25 @@ from champi_imgui.widgets.input import (
     RadioButtonWidget,
     SelectableWidget,
 )
+from champi_imgui.widgets.menu import (
+    ContextMenuWidget,
+    MenuBarWidget,
+    MenuItemWidget,
+    MenuWidget,
+    PopupWidget,
+    TooltipWidget,
+    TreeNodeWidget,
+)
+from champi_imgui.widgets.plotting import (
+    BarChartWidget,
+    ErrorBarsWidget,
+    HeatmapWidget,
+    HistogramWidget,
+    LineChartWidget,
+    PieChartWidget,
+    RealtimePlotWidget,
+    ScatterPlotWidget,
+)
 from champi_imgui.widgets.progress import (
     LoadingIndicatorWidget,
     ProgressBarWidget,
@@ -72,6 +93,7 @@ from champi_imgui.widgets.slider import (
 
 __all__ = [
     "ArrowButtonWidget",
+    "BarChartWidget",
     "BulletTextWidget",
     "BulletWidget",
     "ButtonWidget",
@@ -85,11 +107,15 @@ __all__ = [
     "ColorPicker3Widget",
     "ColorPickerWidget",
     "ComboWidget",
+    "ContextMenuWidget",
     "DragFloatWidget",
     "DragIntWidget",
     "DummyWidget",
+    "ErrorBarsWidget",
     "GroupWidget",
+    "HeatmapWidget",
     "HelpMarkerWidget",
+    "HistogramWidget",
     "InputDoubleWidget",
     "InputFloatWidget",
     "InputIntWidget",
@@ -97,11 +123,19 @@ __all__ = [
     "InputTextWidget",
     "InvisibleButtonWidget",
     "LabelTextWidget",
+    "LineChartWidget",
     "ListBoxWidget",
     "LoadingIndicatorWidget",
+    "MenuBarWidget",
+    "MenuItemWidget",
+    "MenuWidget",
+    "PieChartWidget",
     "PlotLinesWidget",
+    "PopupWidget",
     "ProgressBarWidget",
     "RadioButtonWidget",
+    "RealtimePlotWidget",
+    "ScatterPlotWidget",
     "SelectableWidget",
     "SeparatorWidget",
     "SliderFloatWidget",
@@ -115,5 +149,7 @@ __all__ = [
     "TextDisabledWidget",
     "TextWidget",
     "TextWrappedWidget",
+    "TooltipWidget",
+    "TreeNodeWidget",
     "WindowWidget",
 ]

--- a/src/champi_imgui/widgets/menu.py
+++ b/src/champi_imgui/widgets/menu.py
@@ -1,0 +1,299 @@
+"""Menu and navigation widgets.
+
+This module contains widgets for building menus and navigation structures:
+- MenuBarWidget: Main application menu bar
+- MenuWidget: Dropdown menu container
+- MenuItemWidget: Clickable menu item with optional shortcut and selection state
+- TreeNodeWidget: Collapsible tree node for hierarchical data
+- TooltipWidget: Hover tooltip
+- PopupWidget: Modal and non-modal popup windows
+- ContextMenuWidget: Right-click context menu
+"""
+
+from imgui_bundle import imgui
+
+from champi_imgui.core.widget import Widget
+
+
+class MenuBarWidget(Widget):
+    """Main menu bar widget.
+
+    Renders a menu bar anchored to the top of the application window.
+    Use end_render() to finalize the menu bar after adding child menus.
+    """
+
+    def __init__(self, widget_id: str, **props):
+        """Initialize menu bar.
+
+        Args:
+            widget_id: Unique widget identifier
+            **props: Additional properties
+        """
+        super().__init__(widget_id, **props)
+
+    def render(self) -> bool:
+        """Render the menu bar.
+
+        Returns:
+            True if the menu bar is visible and rendering should continue
+        """
+        return imgui.begin_main_menu_bar()
+
+    def end_render(self) -> None:
+        """End menu bar rendering."""
+        imgui.end_main_menu_bar()
+
+
+class MenuWidget(Widget):
+    """Dropdown menu container widget.
+
+    Renders a collapsible menu that can contain menu items.
+    Use end_render() to finalize the menu after adding items.
+    """
+
+    def __init__(
+        self,
+        widget_id: str,
+        label: str = "Menu",
+        enabled: bool = True,
+        **props,
+    ):
+        """Initialize menu.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Menu label text
+            enabled: Whether the menu is enabled (clickable)
+            **props: Additional properties
+        """
+        props["label"] = label
+        props["enabled"] = enabled
+        super().__init__(widget_id, **props)
+
+    def render(self) -> bool:
+        """Render the menu.
+
+        Returns:
+            True if the menu is open and items should be rendered
+        """
+        label = self.state.properties.get("label", "Menu")
+        enabled = self.state.properties.get("enabled", True)
+
+        return imgui.begin_menu(label, enabled)
+
+    def end_render(self) -> None:
+        """End menu rendering."""
+        imgui.end_menu()
+
+
+class MenuItemWidget(Widget):
+    """Menu item widget.
+
+    A clickable item within a MenuWidget. Supports keyboard shortcuts
+    and toggle selection state.
+    """
+
+    def __init__(
+        self,
+        widget_id: str,
+        label: str = "Item",
+        shortcut: str | None = None,
+        selected: bool = False,
+        enabled: bool = True,
+        **props,
+    ):
+        """Initialize menu item.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Item label text
+            shortcut: Optional keyboard shortcut hint (display only)
+            selected: Whether the item is initially selected/checked
+            enabled: Whether the item is enabled (clickable)
+            **props: Additional properties
+        """
+        props["label"] = label
+        props["shortcut"] = shortcut
+        props["selected"] = selected
+        props["enabled"] = enabled
+        super().__init__(widget_id, **props)
+
+    def render(self) -> tuple[bool, bool]:
+        """Render the menu item.
+
+        Returns:
+            Tuple of (clicked, selected) booleans
+        """
+        label = self.state.properties.get("label", "Item")
+        shortcut: str = self.state.properties.get("shortcut") or ""
+        selected = self.state.properties.get("selected", False)
+        enabled = self.state.properties.get("enabled", True)
+
+        clicked, selected = imgui.menu_item(label, shortcut, selected, enabled)
+
+        if clicked:
+            self.state.properties["selected"] = selected
+            self.trigger_callback("on_click", selected)
+
+        return clicked, selected
+
+
+class TreeNodeWidget(Widget):
+    """Tree node widget for hierarchical data.
+
+    Renders a collapsible tree node. Use end_render() to finalize
+    child content when the node is open.
+    """
+
+    def __init__(
+        self,
+        widget_id: str,
+        label: str = "Node",
+        default_open: bool = False,
+        **props,
+    ):
+        """Initialize tree node.
+
+        Args:
+            widget_id: Unique widget identifier
+            label: Node label text
+            default_open: Whether the node starts in the open state
+            **props: Additional properties
+        """
+        props["label"] = label
+        props["is_open"] = default_open
+        super().__init__(widget_id, **props)
+
+    def render(self) -> bool:
+        """Render the tree node.
+
+        Returns:
+            True if the node is open and children should be rendered
+        """
+        label = self.state.properties.get("label", "Node")
+        flags = self.state.properties.get("flags", 0)
+
+        is_open = imgui.tree_node_ex(label, flags)
+        self.state.properties["is_open"] = is_open
+
+        if is_open:
+            self.trigger_callback("on_open")
+
+        return is_open
+
+    def end_render(self) -> None:
+        """End tree node rendering (calls tree_pop if open)."""
+        if self.state.properties.get("is_open", False):
+            imgui.tree_pop()
+
+
+class TooltipWidget(Widget):
+    """Tooltip widget.
+
+    Displays a tooltip text, typically shown when hovering over an item.
+    """
+
+    def __init__(self, widget_id: str, text: str = "", **props):
+        """Initialize tooltip.
+
+        Args:
+            widget_id: Unique widget identifier
+            text: Tooltip text to display
+            **props: Additional properties
+        """
+        props["text"] = text
+        super().__init__(widget_id, **props)
+
+    def render(self) -> None:
+        """Render the tooltip."""
+        text = self.state.properties.get("text", "")
+        imgui.set_tooltip(text)
+
+
+class PopupWidget(Widget):
+    """Generic popup widget.
+
+    Supports both modal and non-modal popup windows. Use open() to
+    trigger the popup and close() to dismiss it programmatically.
+    """
+
+    def __init__(
+        self,
+        widget_id: str,
+        title: str = "Popup",
+        modal: bool = False,
+        **props,
+    ):
+        """Initialize popup.
+
+        Args:
+            widget_id: Unique widget identifier
+            title: Popup window title
+            modal: If True, renders as a blocking modal dialog
+            **props: Additional properties
+        """
+        props["title"] = title
+        props["modal"] = modal
+        props["is_open"] = False
+        super().__init__(widget_id, **props)
+
+    def open(self) -> None:
+        """Open the popup."""
+        self.state.properties["is_open"] = True
+        imgui.open_popup(self.widget_id)
+
+    def render(self) -> bool:
+        """Render the popup.
+
+        Returns:
+            True if the popup is open and content should be rendered
+        """
+        title = self.state.properties.get("title", "Popup")
+        modal = self.state.properties.get("modal", False)
+        flags = self.state.properties.get("flags", 0)
+
+        if modal:
+            is_open, still_open = imgui.begin_popup_modal(title, True, flags)
+            self.state.properties["is_open"] = still_open
+        else:
+            is_open = imgui.begin_popup(self.widget_id, flags)
+
+        if is_open:
+            imgui.end_popup()
+
+        return is_open
+
+    def close(self) -> None:
+        """Close the popup."""
+        self.state.properties["is_open"] = False
+        imgui.close_current_popup()
+
+
+class ContextMenuWidget(Widget):
+    """Context menu (right-click menu) widget.
+
+    Renders a popup menu triggered by right-clicking on an item.
+    Use end_render() after adding menu items.
+    """
+
+    def __init__(self, widget_id: str, **props):
+        """Initialize context menu.
+
+        Args:
+            widget_id: Unique widget identifier
+            **props: Additional properties (popup_flags, etc.)
+        """
+        super().__init__(widget_id, **props)
+
+    def render(self) -> bool:
+        """Render the context menu.
+
+        Returns:
+            True if the context menu is open
+        """
+        popup_flags = self.state.properties.get("popup_flags", 1)
+        return imgui.begin_popup_context_item(self.widget_id, popup_flags)
+
+    def end_render(self) -> None:
+        """End context menu rendering."""
+        imgui.end_popup()

--- a/src/champi_imgui/widgets/plotting.py
+++ b/src/champi_imgui/widgets/plotting.py
@@ -1,0 +1,371 @@
+"""Advanced plotting widgets using ImPlot."""
+
+import numpy as np
+from imgui_bundle import imgui, implot
+
+from champi_imgui.core.widget import Widget
+
+
+class PlotWidget(Widget):
+    """Base plot widget using ImPlot."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        title: str = "Plot",
+        size: tuple[float, float] = (-1, -1),
+        **props,
+    ):
+        """Initialize plot widget."""
+        props["title"] = title
+        props["size"] = size
+        props["x_label"] = props.get("x_label", "X")
+        props["y_label"] = props.get("y_label", "Y")
+        props["legend"] = props.get("legend", True)
+        super().__init__(widget_id, **props)
+
+    def begin_plot(self) -> bool:
+        """Begin plot rendering."""
+        title = self.state.properties.get("title", "Plot")
+        size = self.state.properties.get("size", (-1, -1))
+        flags = self.state.properties.get("flags", 0)
+
+        return implot.begin_plot(title, imgui.ImVec2(*size), flags)
+
+    def end_plot(self) -> None:
+        """End plot rendering."""
+        implot.end_plot()
+
+    def setup_axes(self) -> None:
+        """Setup plot axes."""
+        x_label = self.state.properties.get("x_label", "X")
+        y_label = self.state.properties.get("y_label", "Y")
+        x_flags = self.state.properties.get("x_flags", 0)
+        y_flags = self.state.properties.get("y_flags", 0)
+
+        implot.setup_axes(x_label, y_label, x_flags, y_flags)
+
+    def render(self) -> None:
+        """Render the plot widget (override in subclasses)."""
+
+
+class LineChartWidget(PlotWidget):
+    """Line chart widget."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        title: str = "Line Chart",
+        x_data: list[float] | None = None,
+        y_data: list[float] | None = None,
+        **props,
+    ):
+        """Initialize line chart."""
+        props["x_data"] = x_data or []
+        props["y_data"] = y_data or []
+        props["line_label"] = props.get("line_label", "Line")
+        super().__init__(widget_id, title, **props)
+
+    def render(self) -> None:
+        """Render line chart."""
+        if self.begin_plot():
+            self.setup_axes()
+
+            x_data = self.state.properties.get("x_data", [])
+            y_data = self.state.properties.get("y_data", [])
+            line_label = self.state.properties.get("line_label", "Line")
+
+            if x_data and y_data and len(x_data) == len(y_data):
+                implot.plot_line(
+                    line_label,
+                    np.array(x_data, dtype=np.float64),
+                    np.array(y_data, dtype=np.float64),
+                )
+
+            self.end_plot()
+
+
+class BarChartWidget(PlotWidget):
+    """Bar chart widget."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        title: str = "Bar Chart",
+        values: list[float] | None = None,
+        labels: list[str] | None = None,
+        **props,
+    ):
+        """Initialize bar chart."""
+        props["values"] = values or []
+        props["labels"] = labels or []
+        props["bar_label"] = props.get("bar_label", "Bars")
+        props["bar_width"] = props.get("bar_width", 0.67)
+        super().__init__(widget_id, title, **props)
+
+    def render(self) -> None:
+        """Render bar chart."""
+        if self.begin_plot():
+            self.setup_axes()
+
+            values = self.state.properties.get("values", [])
+            bar_label = self.state.properties.get("bar_label", "Bars")
+            bar_width = self.state.properties.get("bar_width", 0.67)
+
+            if values:
+                implot.plot_bars(
+                    bar_label,
+                    np.array(values, dtype=np.float64),
+                    bar_width,
+                )
+
+            self.end_plot()
+
+
+class ScatterPlotWidget(PlotWidget):
+    """Scatter plot widget."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        title: str = "Scatter Plot",
+        x_data: list[float] | None = None,
+        y_data: list[float] | None = None,
+        **props,
+    ):
+        """Initialize scatter plot."""
+        props["x_data"] = x_data or []
+        props["y_data"] = y_data or []
+        props["scatter_label"] = props.get("scatter_label", "Points")
+        super().__init__(widget_id, title, **props)
+
+    def render(self) -> None:
+        """Render scatter plot."""
+        if self.begin_plot():
+            self.setup_axes()
+
+            x_data = self.state.properties.get("x_data", [])
+            y_data = self.state.properties.get("y_data", [])
+            scatter_label = self.state.properties.get("scatter_label", "Points")
+
+            if x_data and y_data and len(x_data) == len(y_data):
+                implot.plot_scatter(
+                    scatter_label,
+                    np.array(x_data, dtype=np.float64),
+                    np.array(y_data, dtype=np.float64),
+                )
+
+            self.end_plot()
+
+
+class HistogramWidget(PlotWidget):
+    """Histogram widget."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        title: str = "Histogram",
+        values: list[float] | None = None,
+        bins: int = 10,
+        **props,
+    ):
+        """Initialize histogram."""
+        props["values"] = values or []
+        props["bins"] = bins
+        props["histogram_label"] = props.get("histogram_label", "Distribution")
+        super().__init__(widget_id, title, **props)
+
+    def render(self) -> None:
+        """Render histogram."""
+        if self.begin_plot():
+            self.setup_axes()
+
+            values = self.state.properties.get("values", [])
+            bins = self.state.properties.get("bins", 10)
+            histogram_label = self.state.properties.get(
+                "histogram_label", "Distribution"
+            )
+
+            if values:
+                implot.plot_histogram(
+                    histogram_label,
+                    np.array(values, dtype=np.float64),
+                    bins,
+                )
+
+            self.end_plot()
+
+
+class HeatmapWidget(PlotWidget):
+    """Heatmap widget."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        title: str = "Heatmap",
+        values: list[list[float]] | None = None,
+        **props,
+    ):
+        """Initialize heatmap."""
+        props["values"] = values or []
+        props["heatmap_label"] = props.get("heatmap_label", "Heatmap")
+        props["scale_min"] = props.get("scale_min", 0.0)
+        props["scale_max"] = props.get("scale_max", 1.0)
+        super().__init__(widget_id, title, **props)
+
+    def render(self) -> None:
+        """Render heatmap."""
+        if self.begin_plot():
+            self.setup_axes()
+
+            values = self.state.properties.get("values", [])
+            heatmap_label = self.state.properties.get("heatmap_label", "Heatmap")
+            scale_min = self.state.properties.get("scale_min", 0.0)
+            scale_max = self.state.properties.get("scale_max", 1.0)
+
+            if values and len(values) > 0 and len(values[0]) > 0:
+                arr = np.array(values, dtype=np.float64)
+                implot.plot_heatmap(
+                    heatmap_label,
+                    arr,
+                    scale_min,
+                    scale_max,
+                )
+
+            self.end_plot()
+
+
+class PieChartWidget(Widget):
+    """Pie chart widget."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        values: list[float] | None = None,
+        labels: list[str] | None = None,
+        center: tuple[float, float] = (0.5, 0.5),
+        radius: float = 0.4,
+        **props,
+    ):
+        """Initialize pie chart."""
+        props["values"] = values or []
+        props["labels"] = labels or []
+        props["center"] = center
+        props["radius"] = radius
+        super().__init__(widget_id, **props)
+
+    def render(self) -> None:
+        """Render pie chart."""
+        values = self.state.properties.get("values", [])
+        labels = self.state.properties.get("labels", [])
+        center = self.state.properties.get("center", (0.5, 0.5))
+        radius = self.state.properties.get("radius", 0.4)
+
+        if (
+            values
+            and labels
+            and len(values) == len(labels)
+            and implot.begin_plot("##pie", imgui.ImVec2(-1, -1))
+        ):
+            implot.setup_axes("", "", implot.AxisFlags_.no_decorations)
+            implot.plot_pie_chart(
+                labels,
+                np.array(values, dtype=np.float64),
+                center[0],
+                center[1],
+                radius,
+            )
+            implot.end_plot()
+
+
+class RealtimePlotWidget(PlotWidget):
+    """Realtime scrolling plot widget."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        title: str = "Realtime Plot",
+        max_points: int = 1000,
+        **props,
+    ):
+        """Initialize realtime plot."""
+        props["data"] = []
+        props["max_points"] = max_points
+        props["line_label"] = props.get("line_label", "Signal")
+        super().__init__(widget_id, title, **props)
+
+    def add_point(self, value: float) -> None:
+        """Add a data point."""
+        data = self.state.properties.get("data", [])
+        max_points = self.state.properties.get("max_points", 1000)
+
+        data.append(value)
+
+        if len(data) > max_points:
+            data.pop(0)
+
+        self.state.properties["data"] = data
+
+    def render(self) -> None:
+        """Render realtime plot."""
+        if self.begin_plot():
+            implot.setup_axes_limits(
+                0, self.state.properties.get("max_points", 1000), -1, 1
+            )
+
+            data = self.state.properties.get("data", [])
+            line_label = self.state.properties.get("line_label", "Signal")
+
+            if data:
+                x_data = np.arange(len(data), dtype=np.float64)
+                implot.plot_line(
+                    line_label,
+                    x_data,
+                    np.array(data, dtype=np.float64),
+                )
+
+            self.end_plot()
+
+
+class ErrorBarsWidget(PlotWidget):
+    """Plot with error bars."""
+
+    def __init__(
+        self,
+        widget_id: str,
+        title: str = "Error Bars",
+        x_data: list[float] | None = None,
+        y_data: list[float] | None = None,
+        y_errors: list[float] | None = None,
+        **props,
+    ):
+        """Initialize error bars plot."""
+        props["x_data"] = x_data or []
+        props["y_data"] = y_data or []
+        props["y_errors"] = y_errors or []
+        props["error_label"] = props.get("error_label", "Data")
+        super().__init__(widget_id, title, **props)
+
+    def render(self) -> None:
+        """Render error bars."""
+        if self.begin_plot():
+            self.setup_axes()
+
+            x_data = self.state.properties.get("x_data", [])
+            y_data = self.state.properties.get("y_data", [])
+            y_errors = self.state.properties.get("y_errors", [])
+            error_label = self.state.properties.get("error_label", "Data")
+
+            if (
+                x_data
+                and y_data
+                and y_errors
+                and len(x_data) == len(y_data) == len(y_errors)
+            ):
+                xs = np.array(x_data, dtype=np.float64)
+                ys = np.array(y_data, dtype=np.float64)
+                errs = np.array(y_errors, dtype=np.float64)
+                implot.plot_error_bars(error_label, xs, ys, errs)
+                implot.plot_line(error_label, xs, ys)
+
+            self.end_plot()

--- a/tests/test_menu_widgets.py
+++ b/tests/test_menu_widgets.py
@@ -1,0 +1,346 @@
+"""Comprehensive tests for menu and navigation widgets.
+
+Tests cover all menu widgets:
+- MenuBarWidget
+- MenuWidget
+- MenuItemWidget
+- TreeNodeWidget
+- TooltipWidget
+- PopupWidget
+- ContextMenuWidget
+"""
+
+from champi_imgui.core.state import WidgetState
+from champi_imgui.widgets.menu import (
+    ContextMenuWidget,
+    MenuBarWidget,
+    MenuItemWidget,
+    MenuWidget,
+    PopupWidget,
+    TooltipWidget,
+    TreeNodeWidget,
+)
+
+# ==============================================================================
+# MenuBarWidget Tests
+# ==============================================================================
+
+
+def test_menu_bar_creation():
+    """Test MenuBarWidget creation with default values."""
+    widget = MenuBarWidget("menubar-1")
+
+    assert widget.widget_id == "menubar-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_type == "MenuBarWidget"
+
+
+def test_menu_bar_visibility():
+    """Test MenuBarWidget visibility state."""
+    widget = MenuBarWidget("menubar-2")
+
+    assert widget.state.visible is True
+    widget.set_visible(False)
+    assert widget.state.visible is False
+
+
+def test_menu_bar_serialization():
+    """Test MenuBarWidget serialization."""
+    widget = MenuBarWidget("menubar-3")
+
+    data = widget.serialize()
+
+    assert data["widget_id"] == "menubar-3"
+    assert data["widget_type"] == "MenuBarWidget"
+
+
+# ==============================================================================
+# MenuWidget Tests
+# ==============================================================================
+
+
+def test_menu_widget_creation_defaults():
+    """Test MenuWidget creation with default values."""
+    widget = MenuWidget("menu-1")
+
+    assert widget.widget_id == "menu-1"
+    assert widget.state.widget_type == "MenuWidget"
+    assert widget.state.properties["label"] == "Menu"
+    assert widget.state.properties["enabled"] is True
+
+
+def test_menu_widget_custom_label():
+    """Test MenuWidget with custom label."""
+    widget = MenuWidget("menu-2", label="File")
+
+    assert widget.state.properties["label"] == "File"
+
+
+def test_menu_widget_disabled():
+    """Test MenuWidget with disabled state."""
+    widget = MenuWidget("menu-3", label="Edit", enabled=False)
+
+    assert widget.state.properties["enabled"] is False
+
+
+def test_menu_widget_serialization():
+    """Test MenuWidget serialization."""
+    widget = MenuWidget("menu-4", label="View", enabled=True)
+
+    data = widget.serialize()
+
+    assert data["widget_id"] == "menu-4"
+    assert data["widget_type"] == "MenuWidget"
+    assert data["properties"]["label"] == "View"
+    assert data["properties"]["enabled"] is True
+
+
+# ==============================================================================
+# MenuItemWidget Tests
+# ==============================================================================
+
+
+def test_menu_item_creation_defaults():
+    """Test MenuItemWidget creation with default values."""
+    widget = MenuItemWidget("item-1")
+
+    assert widget.widget_id == "item-1"
+    assert widget.state.widget_type == "MenuItemWidget"
+    assert widget.state.properties["label"] == "Item"
+    assert widget.state.properties["shortcut"] is None
+    assert widget.state.properties["selected"] is False
+    assert widget.state.properties["enabled"] is True
+
+
+def test_menu_item_with_shortcut():
+    """Test MenuItemWidget with keyboard shortcut."""
+    widget = MenuItemWidget("item-2", label="Save", shortcut="Ctrl+S")
+
+    assert widget.state.properties["label"] == "Save"
+    assert widget.state.properties["shortcut"] == "Ctrl+S"
+
+
+def test_menu_item_with_selection():
+    """Test MenuItemWidget with selected state."""
+    widget = MenuItemWidget("item-3", label="Toggle", selected=True)
+
+    assert widget.state.properties["selected"] is True
+
+
+def test_menu_item_disabled():
+    """Test MenuItemWidget in disabled state."""
+    widget = MenuItemWidget("item-4", label="Disabled", enabled=False)
+
+    assert widget.state.properties["enabled"] is False
+
+
+def test_menu_item_serialization():
+    """Test MenuItemWidget serialization."""
+    widget = MenuItemWidget("item-5", label="Open", shortcut="Ctrl+O", selected=False)
+
+    data = widget.serialize()
+
+    assert data["widget_id"] == "item-5"
+    assert data["widget_type"] == "MenuItemWidget"
+    assert data["properties"]["label"] == "Open"
+    assert data["properties"]["shortcut"] == "Ctrl+O"
+
+
+def test_menu_item_callback_registration():
+    """Test that MenuItemWidget supports callback registration."""
+    widget = MenuItemWidget("item-6", label="Exit")
+
+    callback_called = []
+
+    def on_click(selected):
+        callback_called.append(selected)
+
+    widget.register_callback("on_click", on_click)
+    assert "on_click" in widget._callbacks
+
+
+# ==============================================================================
+# TreeNodeWidget Tests
+# ==============================================================================
+
+
+def test_tree_node_creation_defaults():
+    """Test TreeNodeWidget creation with default values."""
+    widget = TreeNodeWidget("tree-1")
+
+    assert widget.widget_id == "tree-1"
+    assert widget.state.widget_type == "TreeNodeWidget"
+    assert widget.state.properties["label"] == "Node"
+    assert widget.state.properties["is_open"] is False
+
+
+def test_tree_node_custom_label():
+    """Test TreeNodeWidget with custom label."""
+    widget = TreeNodeWidget("tree-2", label="Children")
+
+    assert widget.state.properties["label"] == "Children"
+
+
+def test_tree_node_default_open():
+    """Test TreeNodeWidget starting in open state."""
+    widget = TreeNodeWidget("tree-3", label="Open Node", default_open=True)
+
+    assert widget.state.properties["is_open"] is True
+
+
+def test_tree_node_serialization():
+    """Test TreeNodeWidget serialization."""
+    widget = TreeNodeWidget("tree-4", label="Root", default_open=True)
+
+    data = widget.serialize()
+
+    assert data["widget_id"] == "tree-4"
+    assert data["widget_type"] == "TreeNodeWidget"
+    assert data["properties"]["label"] == "Root"
+    assert data["properties"]["is_open"] is True
+
+
+def test_tree_node_callback_registration():
+    """Test that TreeNodeWidget supports callback registration."""
+    widget = TreeNodeWidget("tree-5", label="Node")
+
+    callback_called = []
+
+    def on_open():
+        callback_called.append(True)
+
+    widget.register_callback("on_open", on_open)
+    assert "on_open" in widget._callbacks
+
+
+# ==============================================================================
+# TooltipWidget Tests
+# ==============================================================================
+
+
+def test_tooltip_creation_defaults():
+    """Test TooltipWidget creation with default values."""
+    widget = TooltipWidget("tip-1")
+
+    assert widget.widget_id == "tip-1"
+    assert widget.state.widget_type == "TooltipWidget"
+    assert widget.state.properties["text"] == ""
+
+
+def test_tooltip_with_text():
+    """Test TooltipWidget with custom text."""
+    widget = TooltipWidget("tip-2", text="This is helpful")
+
+    assert widget.state.properties["text"] == "This is helpful"
+
+
+def test_tooltip_serialization():
+    """Test TooltipWidget serialization."""
+    widget = TooltipWidget("tip-3", text="Hover info")
+
+    data = widget.serialize()
+
+    assert data["widget_id"] == "tip-3"
+    assert data["widget_type"] == "TooltipWidget"
+    assert data["properties"]["text"] == "Hover info"
+
+
+# ==============================================================================
+# PopupWidget Tests
+# ==============================================================================
+
+
+def test_popup_creation_defaults():
+    """Test PopupWidget creation with default values."""
+    widget = PopupWidget("popup-1")
+
+    assert widget.widget_id == "popup-1"
+    assert widget.state.widget_type == "PopupWidget"
+    assert widget.state.properties["title"] == "Popup"
+    assert widget.state.properties["modal"] is False
+    assert widget.state.properties["is_open"] is False
+
+
+def test_popup_modal():
+    """Test PopupWidget as modal dialog."""
+    widget = PopupWidget("popup-2", title="Confirm", modal=True)
+
+    assert widget.state.properties["title"] == "Confirm"
+    assert widget.state.properties["modal"] is True
+
+
+def test_popup_open_state():
+    """Test PopupWidget open state tracking."""
+    widget = PopupWidget("popup-3", title="Dialog")
+
+    assert widget.state.properties["is_open"] is False
+    widget.state.properties["is_open"] = True
+    assert widget.state.properties["is_open"] is True
+
+
+def test_popup_serialization():
+    """Test PopupWidget serialization."""
+    widget = PopupWidget("popup-4", title="Alert", modal=False)
+
+    data = widget.serialize()
+
+    assert data["widget_id"] == "popup-4"
+    assert data["widget_type"] == "PopupWidget"
+    assert data["properties"]["title"] == "Alert"
+    assert data["properties"]["modal"] is False
+
+
+# ==============================================================================
+# ContextMenuWidget Tests
+# ==============================================================================
+
+
+def test_context_menu_creation():
+    """Test ContextMenuWidget creation."""
+    widget = ContextMenuWidget("ctx-1")
+
+    assert widget.widget_id == "ctx-1"
+    assert widget.state.widget_type == "ContextMenuWidget"
+
+
+def test_context_menu_custom_flags():
+    """Test ContextMenuWidget with custom popup flags."""
+    widget = ContextMenuWidget("ctx-2", popup_flags=2)
+
+    assert widget.state.properties["popup_flags"] == 2
+
+
+def test_context_menu_serialization():
+    """Test ContextMenuWidget serialization."""
+    widget = ContextMenuWidget("ctx-3")
+
+    data = widget.serialize()
+
+    assert data["widget_id"] == "ctx-3"
+    assert data["widget_type"] == "ContextMenuWidget"
+
+
+# ==============================================================================
+# __init__.py Export Tests
+# ==============================================================================
+
+
+def test_menu_widgets_exported_from_package():
+    """Test that menu widgets are exported from the widgets package."""
+    from champi_imgui.widgets import (
+        ContextMenuWidget,
+        MenuBarWidget,
+        MenuItemWidget,
+        MenuWidget,
+        PopupWidget,
+        TooltipWidget,
+        TreeNodeWidget,
+    )
+
+    assert MenuBarWidget is not None
+    assert MenuWidget is not None
+    assert MenuItemWidget is not None
+    assert TreeNodeWidget is not None
+    assert TooltipWidget is not None
+    assert PopupWidget is not None
+    assert ContextMenuWidget is not None

--- a/tests/test_plotting_widgets.py
+++ b/tests/test_plotting_widgets.py
@@ -1,0 +1,452 @@
+"""Tests for plotting widgets (ImPlot-based).
+
+Tests cover all 8 plotting widgets:
+- LineChartWidget
+- BarChartWidget
+- ScatterPlotWidget
+- HistogramWidget
+- HeatmapWidget
+- PieChartWidget
+- RealtimePlotWidget
+- ErrorBarsWidget
+"""
+
+from champi_imgui.core.state import WidgetState
+from champi_imgui.widgets.plotting import (
+    BarChartWidget,
+    ErrorBarsWidget,
+    HeatmapWidget,
+    HistogramWidget,
+    LineChartWidget,
+    PieChartWidget,
+    RealtimePlotWidget,
+    ScatterPlotWidget,
+)
+
+# ==============================================================================
+# LineChartWidget Tests
+# ==============================================================================
+
+
+def test_line_chart_widget_creation_defaults():
+    """Test LineChartWidget creation with default values."""
+    widget = LineChartWidget("line-1")
+
+    assert widget.widget_id == "line-1"
+    assert isinstance(widget.state, WidgetState)
+    assert widget.state.widget_type == "LineChartWidget"
+    assert widget.state.properties["title"] == "Line Chart"
+    assert widget.state.properties["x_data"] == []
+    assert widget.state.properties["y_data"] == []
+    assert widget.state.properties["line_label"] == "Line"
+
+
+def test_line_chart_widget_creation_with_data():
+    """Test LineChartWidget creation with data."""
+    x_data = [0.0, 1.0, 2.0, 3.0]
+    y_data = [0.0, 1.0, 0.5, 2.0]
+    widget = LineChartWidget(
+        "line-2",
+        title="My Chart",
+        x_data=x_data,
+        y_data=y_data,
+        line_label="Series A",
+    )
+
+    assert widget.state.properties["title"] == "My Chart"
+    assert widget.state.properties["x_data"] == x_data
+    assert widget.state.properties["y_data"] == y_data
+    assert widget.state.properties["line_label"] == "Series A"
+
+
+def test_line_chart_widget_visibility():
+    """Test LineChartWidget visibility handling."""
+    widget = LineChartWidget("line-3")
+
+    assert widget.state.visible is True
+
+    widget.set_visible(False)
+    assert widget.state.visible is False
+
+
+def test_line_chart_widget_serialization():
+    """Test LineChartWidget serialization."""
+    x_data = [1.0, 2.0]
+    y_data = [3.0, 4.0]
+    widget = LineChartWidget(
+        "line-4", title="Serial Chart", x_data=x_data, y_data=y_data
+    )
+
+    data = widget.serialize()
+
+    assert data["widget_id"] == "line-4"
+    assert data["widget_type"] == "LineChartWidget"
+    assert data["properties"]["title"] == "Serial Chart"
+    assert data["properties"]["x_data"] == x_data
+    assert data["properties"]["y_data"] == y_data
+
+
+def test_line_chart_widget_update():
+    """Test LineChartWidget property update."""
+    widget = LineChartWidget("line-5")
+
+    widget.update(x_data=[0.0, 1.0], y_data=[0.5, 1.5])
+
+    assert widget.state.properties["x_data"] == [0.0, 1.0]
+    assert widget.state.properties["y_data"] == [0.5, 1.5]
+
+
+# ==============================================================================
+# BarChartWidget Tests
+# ==============================================================================
+
+
+def test_bar_chart_widget_creation_defaults():
+    """Test BarChartWidget creation with default values."""
+    widget = BarChartWidget("bar-1")
+
+    assert widget.widget_id == "bar-1"
+    assert widget.state.widget_type == "BarChartWidget"
+    assert widget.state.properties["title"] == "Bar Chart"
+    assert widget.state.properties["values"] == []
+    assert widget.state.properties["labels"] == []
+    assert widget.state.properties["bar_label"] == "Bars"
+    assert widget.state.properties["bar_width"] == 0.67
+
+
+def test_bar_chart_widget_creation_with_data():
+    """Test BarChartWidget creation with data."""
+    values = [10.0, 20.0, 15.0]
+    labels = ["A", "B", "C"]
+    widget = BarChartWidget(
+        "bar-2",
+        title="Sales",
+        values=values,
+        labels=labels,
+        bar_label="Revenue",
+        bar_width=0.5,
+    )
+
+    assert widget.state.properties["values"] == values
+    assert widget.state.properties["labels"] == labels
+    assert widget.state.properties["bar_label"] == "Revenue"
+    assert widget.state.properties["bar_width"] == 0.5
+
+
+def test_bar_chart_widget_serialization():
+    """Test BarChartWidget serialization."""
+    widget = BarChartWidget("bar-3", values=[1.0, 2.0], labels=["X", "Y"])
+
+    data = widget.serialize()
+
+    assert data["widget_id"] == "bar-3"
+    assert data["widget_type"] == "BarChartWidget"
+    assert data["properties"]["values"] == [1.0, 2.0]
+
+
+# ==============================================================================
+# ScatterPlotWidget Tests
+# ==============================================================================
+
+
+def test_scatter_plot_widget_creation_defaults():
+    """Test ScatterPlotWidget creation with default values."""
+    widget = ScatterPlotWidget("scatter-1")
+
+    assert widget.widget_id == "scatter-1"
+    assert widget.state.widget_type == "ScatterPlotWidget"
+    assert widget.state.properties["title"] == "Scatter Plot"
+    assert widget.state.properties["x_data"] == []
+    assert widget.state.properties["y_data"] == []
+    assert widget.state.properties["scatter_label"] == "Points"
+
+
+def test_scatter_plot_widget_creation_with_data():
+    """Test ScatterPlotWidget creation with data."""
+    x_data = [1.0, 2.0, 3.0]
+    y_data = [4.0, 5.0, 6.0]
+    widget = ScatterPlotWidget(
+        "scatter-2",
+        title="My Scatter",
+        x_data=x_data,
+        y_data=y_data,
+        scatter_label="Samples",
+    )
+
+    assert widget.state.properties["x_data"] == x_data
+    assert widget.state.properties["y_data"] == y_data
+    assert widget.state.properties["scatter_label"] == "Samples"
+
+
+def test_scatter_plot_widget_serialization():
+    """Test ScatterPlotWidget serialization."""
+    widget = ScatterPlotWidget("scatter-3", x_data=[0.0], y_data=[1.0])
+
+    data = widget.serialize()
+
+    assert data["widget_id"] == "scatter-3"
+    assert data["widget_type"] == "ScatterPlotWidget"
+
+
+# ==============================================================================
+# HistogramWidget Tests
+# ==============================================================================
+
+
+def test_histogram_widget_creation_defaults():
+    """Test HistogramWidget creation with default values."""
+    widget = HistogramWidget("hist-1")
+
+    assert widget.widget_id == "hist-1"
+    assert widget.state.widget_type == "HistogramWidget"
+    assert widget.state.properties["title"] == "Histogram"
+    assert widget.state.properties["values"] == []
+    assert widget.state.properties["bins"] == 10
+    assert widget.state.properties["histogram_label"] == "Distribution"
+
+
+def test_histogram_widget_creation_with_data():
+    """Test HistogramWidget creation with data."""
+    values = [1.0, 2.0, 2.0, 3.0, 3.0, 3.0]
+    widget = HistogramWidget("hist-2", title="Data Dist", values=values, bins=5)
+
+    assert widget.state.properties["values"] == values
+    assert widget.state.properties["bins"] == 5
+
+
+def test_histogram_widget_serialization():
+    """Test HistogramWidget serialization."""
+    widget = HistogramWidget("hist-3", values=[1.0, 2.0, 3.0], bins=3)
+
+    data = widget.serialize()
+
+    assert data["widget_id"] == "hist-3"
+    assert data["widget_type"] == "HistogramWidget"
+    assert data["properties"]["bins"] == 3
+
+
+# ==============================================================================
+# HeatmapWidget Tests
+# ==============================================================================
+
+
+def test_heatmap_widget_creation_defaults():
+    """Test HeatmapWidget creation with default values."""
+    widget = HeatmapWidget("heat-1")
+
+    assert widget.widget_id == "heat-1"
+    assert widget.state.widget_type == "HeatmapWidget"
+    assert widget.state.properties["title"] == "Heatmap"
+    assert widget.state.properties["values"] == []
+    assert widget.state.properties["heatmap_label"] == "Heatmap"
+    assert widget.state.properties["scale_min"] == 0.0
+    assert widget.state.properties["scale_max"] == 1.0
+
+
+def test_heatmap_widget_creation_with_data():
+    """Test HeatmapWidget creation with 2D data."""
+    values = [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+    widget = HeatmapWidget(
+        "heat-2",
+        title="Temperature Map",
+        values=values,
+        scale_min=-1.0,
+        scale_max=1.0,
+    )
+
+    assert widget.state.properties["values"] == values
+    assert widget.state.properties["scale_min"] == -1.0
+    assert widget.state.properties["scale_max"] == 1.0
+
+
+def test_heatmap_widget_serialization():
+    """Test HeatmapWidget serialization."""
+    values = [[0.5, 0.8], [0.2, 0.9]]
+    widget = HeatmapWidget("heat-3", values=values)
+
+    data = widget.serialize()
+
+    assert data["widget_id"] == "heat-3"
+    assert data["widget_type"] == "HeatmapWidget"
+    assert data["properties"]["values"] == values
+
+
+# ==============================================================================
+# PieChartWidget Tests
+# ==============================================================================
+
+
+def test_pie_chart_widget_creation_defaults():
+    """Test PieChartWidget creation with default values."""
+    widget = PieChartWidget("pie-1")
+
+    assert widget.widget_id == "pie-1"
+    assert widget.state.widget_type == "PieChartWidget"
+    assert widget.state.properties["values"] == []
+    assert widget.state.properties["labels"] == []
+    assert widget.state.properties["center"] == (0.5, 0.5)
+    assert widget.state.properties["radius"] == 0.4
+
+
+def test_pie_chart_widget_creation_with_data():
+    """Test PieChartWidget creation with data."""
+    values = [30.0, 45.0, 25.0]
+    labels = ["A", "B", "C"]
+    widget = PieChartWidget(
+        "pie-2",
+        values=values,
+        labels=labels,
+        center=(0.4, 0.6),
+        radius=0.35,
+    )
+
+    assert widget.state.properties["values"] == values
+    assert widget.state.properties["labels"] == labels
+    assert widget.state.properties["center"] == (0.4, 0.6)
+    assert widget.state.properties["radius"] == 0.35
+
+
+def test_pie_chart_widget_serialization():
+    """Test PieChartWidget serialization."""
+    widget = PieChartWidget("pie-3", values=[50.0, 50.0], labels=["Yes", "No"])
+
+    data = widget.serialize()
+
+    assert data["widget_id"] == "pie-3"
+    assert data["widget_type"] == "PieChartWidget"
+    assert data["properties"]["values"] == [50.0, 50.0]
+    assert data["properties"]["labels"] == ["Yes", "No"]
+
+
+# ==============================================================================
+# RealtimePlotWidget Tests
+# ==============================================================================
+
+
+def test_realtime_plot_widget_creation_defaults():
+    """Test RealtimePlotWidget creation with default values."""
+    widget = RealtimePlotWidget("rt-1")
+
+    assert widget.widget_id == "rt-1"
+    assert widget.state.widget_type == "RealtimePlotWidget"
+    assert widget.state.properties["title"] == "Realtime Plot"
+    assert widget.state.properties["data"] == []
+    assert widget.state.properties["max_points"] == 1000
+    assert widget.state.properties["line_label"] == "Signal"
+
+
+def test_realtime_plot_widget_add_point():
+    """Test RealtimePlotWidget add_point method."""
+    widget = RealtimePlotWidget("rt-2", max_points=5)
+
+    widget.add_point(1.0)
+    widget.add_point(2.0)
+    widget.add_point(3.0)
+
+    assert widget.state.properties["data"] == [1.0, 2.0, 3.0]
+
+
+def test_realtime_plot_widget_max_points_enforcement():
+    """Test RealtimePlotWidget enforces max_points limit."""
+    widget = RealtimePlotWidget("rt-3", max_points=3)
+
+    for i in range(5):
+        widget.add_point(float(i))
+
+    data = widget.state.properties["data"]
+    assert len(data) == 3
+    # Should keep the most recent points
+    assert data == [2.0, 3.0, 4.0]
+
+
+def test_realtime_plot_widget_serialization():
+    """Test RealtimePlotWidget serialization."""
+    widget = RealtimePlotWidget("rt-4", max_points=100)
+
+    data = widget.serialize()
+
+    assert data["widget_id"] == "rt-4"
+    assert data["widget_type"] == "RealtimePlotWidget"
+    assert data["properties"]["max_points"] == 100
+
+
+# ==============================================================================
+# ErrorBarsWidget Tests
+# ==============================================================================
+
+
+def test_error_bars_widget_creation_defaults():
+    """Test ErrorBarsWidget creation with default values."""
+    widget = ErrorBarsWidget("err-1")
+
+    assert widget.widget_id == "err-1"
+    assert widget.state.widget_type == "ErrorBarsWidget"
+    assert widget.state.properties["title"] == "Error Bars"
+    assert widget.state.properties["x_data"] == []
+    assert widget.state.properties["y_data"] == []
+    assert widget.state.properties["y_errors"] == []
+    assert widget.state.properties["error_label"] == "Data"
+
+
+def test_error_bars_widget_creation_with_data():
+    """Test ErrorBarsWidget creation with data."""
+    x_data = [1.0, 2.0, 3.0]
+    y_data = [2.0, 4.0, 3.0]
+    y_errors = [0.1, 0.2, 0.15]
+    widget = ErrorBarsWidget(
+        "err-2",
+        title="Measurements",
+        x_data=x_data,
+        y_data=y_data,
+        y_errors=y_errors,
+        error_label="Exp A",
+    )
+
+    assert widget.state.properties["x_data"] == x_data
+    assert widget.state.properties["y_data"] == y_data
+    assert widget.state.properties["y_errors"] == y_errors
+    assert widget.state.properties["error_label"] == "Exp A"
+
+
+def test_error_bars_widget_serialization():
+    """Test ErrorBarsWidget serialization."""
+    widget = ErrorBarsWidget(
+        "err-3",
+        x_data=[1.0],
+        y_data=[2.0],
+        y_errors=[0.1],
+    )
+
+    data = widget.serialize()
+
+    assert data["widget_id"] == "err-3"
+    assert data["widget_type"] == "ErrorBarsWidget"
+    assert data["properties"]["x_data"] == [1.0]
+
+
+# ==============================================================================
+# Module import tests
+# ==============================================================================
+
+
+def test_plotting_widgets_importable_from_package():
+    """Test that all plotting widgets are importable from the widgets package."""
+    from champi_imgui.widgets import (
+        BarChartWidget,
+        ErrorBarsWidget,
+        HeatmapWidget,
+        HistogramWidget,
+        LineChartWidget,
+        PieChartWidget,
+        RealtimePlotWidget,
+        ScatterPlotWidget,
+    )
+
+    assert LineChartWidget is not None
+    assert BarChartWidget is not None
+    assert ScatterPlotWidget is not None
+    assert HistogramWidget is not None
+    assert HeatmapWidget is not None
+    assert PieChartWidget is not None
+    assert RealtimePlotWidget is not None
+    assert ErrorBarsWidget is not None


### PR DESCRIPTION
## Summary

- Add `src/champi_imgui/widgets/menu.py` with 7 menu/navigation widget classes: `MenuBarWidget`, `MenuWidget`, `MenuItemWidget`, `TreeNodeWidget`, `TooltipWidget`, `PopupWidget`, `ContextMenuWidget`
- Add `src/champi_imgui/widgets/plotting.py` with 8 ImPlot-based widget classes: `LineChartWidget`, `BarChartWidget`, `ScatterPlotWidget`, `HistogramWidget`, `HeatmapWidget`, `PieChartWidget`, `RealtimePlotWidget`, `ErrorBarsWidget`
- All implot API calls use numpy arrays to match the actual imgui-bundle API signatures
- Register all new widgets in `src/champi_imgui/widgets/__init__.py`
- Add `tests/test_menu_widgets.py` with 29 unit tests and `tests/test_plotting_widgets.py` with 28 unit tests

## Test plan

- [ ] All new tests pass (`uv run pytest tests/test_menu_widgets.py tests/test_plotting_widgets.py`)
- [ ] `ruff check` and `ruff format --check` pass on `src/` and `tests/`
- [ ] Full test suite passes

Closes #11
Closes #12