### PR TITLE
fix: prevent CI loop from badge commit and fix release trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,16 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ci-${{ github.head_ref }}
+  cancel-in-progress: true
+
 
 jobs:
   test:
     name: Test on Python ${{ matrix.python-version }}
     runs-on: self-hosted
+    if: "!contains(github.event.head_commit.message, 'update coverage badge')"
     permissions:
       contents: write
     strategy:
@@ -70,7 +75,7 @@ jobs:
         git stash pop
 
         git add badges/coverage.svg pyproject.toml
-        git diff --staged --quiet || git commit -m "chore: update coverage badge and threshold [skip ci]"
+        git diff --staged --quiet || git commit -m "chore: update coverage badge and threshold"
         git push origin HEAD:${{ github.head_ref }}
 
   security:


### PR DESCRIPTION
## Summary
- Remove [skip ci] from badge commit message — it was bleeding into squash merge bodies and suppressing the Release workflow on main
- Add job-level condition to skip CI when the triggering commit is the badge auto-commit
- Add concurrency group to cancel stale runs when new commits arrive on the PR branch

## Test plan
- [ ] Badge commit no longer re-triggers a full CI run
- [ ] Merging to main triggers the Release workflow correctly