### PR TITLE
fix: use renewed RELEASE_TOKEN for push and release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Authenticate git and fetch full history
       run: |
-        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+        git remote set-url origin https://Divagnz:${{ secrets.RELEASE_TOKEN }}@github.com/${{ github.repository }}.git
         git fetch --unshallow --tags
 
     - name: Install uv for commitizen
@@ -59,7 +59,7 @@ jobs:
     - name: Run commitizen bump
       id: cz
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       run: |
         # Get previous version
         PREV_REV=$(cz version --project)
@@ -135,23 +135,10 @@ jobs:
           echo "Incremental changelog:"
           cat body.md
 
-          # Push tag directly (tags are not protected), skip if already exists
           if [[ "${{ github.event.inputs.dry_run }}" != "true" ]]; then
-            git push origin --tags --no-verify 2>/dev/null || true
-            git push origin "refs/tags/v${REV}:refs/tags/v${REV}" 2>/dev/null || echo "Tag v${REV} already on remote, skipping"
-
-            # Open a PR for the bump commit (skip if PR already exists)
-            BRANCH="release/v${REV}"
-            git checkout -b "$BRANCH" 2>/dev/null || git checkout "$BRANCH"
-            git push origin "$BRANCH" --force-with-lease
-            gh pr create \
-              --title "bump: version $PREV_REV → $REV" \
-              --body "$(cat body.md)" \
-              --base main \
-              --head "$BRANCH" \
-              --label "release" 2>/dev/null || echo "PR already exists for $BRANCH"
+            git push origin HEAD:main --tags
           else
-            echo "Dry run mode: skipping push and PR"
+            echo "Dry run mode: skipping push"
           fi
         else
           echo "No version change, skipping release"
@@ -170,10 +157,15 @@ jobs:
 
     - name: Create GitHub Release
       if: steps.cz.outputs.version_changed == 'true' && github.event.inputs.dry_run != 'true'
-      uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2.4.1
-      with:
-        body_path: body.md
-        tag_name: v${{ steps.cz.outputs.version }}
-        files: dist/*
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      run: |
+        TAG="v${{ steps.cz.outputs.version }}"
+        if gh release view "$TAG" &>/dev/null; then
+          echo "Release $TAG already exists, skipping"
+        else
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file body.md \
+            dist/*
+        fi


### PR DESCRIPTION
Switch back to RELEASE_TOKEN (now renewed) for git push to main and gh release create. Simplifies release flow — no PR dance needed since the token has bypass permissions.