### PR TITLE
fix: rebase onto main before push to handle non-fast-forward

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,8 @@ jobs:
           cat body.md
 
           if [[ "${{ github.event.inputs.dry_run }}" != "true" ]]; then
+            git fetch origin main
+            git rebase origin/main
             git push origin HEAD:main --tags
           else
             echo "Dry run mode: skipping push"


### PR DESCRIPTION
Fetch and rebase onto origin/main after cz bump to avoid rejection when main moved since checkout.