### PR TITLE
chore: update release URLs to v1.3.0

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -4,7 +4,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "https://github.com/champi-ai/champi-imgui/releases/download/v1.2.1/champi_imgui-1.2.1-py3-none-any.whl",
+        "https://github.com/champi-ai/champi-imgui/releases/download/v1.2.0/champi_imgui-1.2.0-py3-none-any.whl",
         "champi-imgui",
         "serve"
       ]

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -4,7 +4,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "https://github.com/champi-ai/champi-imgui/releases/download/v1.2.0/champi_imgui-1.2.0-py3-none-any.whl",
+        "https://github.com/champi-ai/champi-imgui/releases/download/v1.2.1/champi_imgui-1.2.1-py3-none-any.whl",
         "champi-imgui",
         "serve"
       ]

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -4,7 +4,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "https://github.com/champi-ai/champi-imgui/releases/download/v1.2.1/champi_imgui-1.2.1-py3-none-any.whl",
+        "https://github.com/champi-ai/champi-imgui/releases/download/v1.3.0/champi_imgui-1.3.0-py3-none-any.whl",
         "champi-imgui",
         "serve"
       ]

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The easiest way to use champi-imgui is via the `.mcp.json` config — no install
       "command": "uvx",
       "args": [
         "--from",
-        "https://github.com/champi-ai/champi-imgui/releases/download/v1.2.0/champi_imgui-1.2.0-py3-none-any.whl",
+        "https://github.com/champi-ai/champi-imgui/releases/download/v1.2.1/champi_imgui-1.2.1-py3-none-any.whl",
         "champi-imgui",
         "serve"
       ]
@@ -59,14 +59,14 @@ Install from the GitHub release:
 
 ```bash
 # Run without installing (ephemeral)
-uvx --from https://github.com/champi-ai/champi-imgui/releases/download/v1.2.0/champi_imgui-1.2.0-py3-none-any.whl champi-imgui serve
+uvx --from https://github.com/champi-ai/champi-imgui/releases/download/v1.2.1/champi_imgui-1.2.1-py3-none-any.whl champi-imgui serve
 
 # Install as a persistent tool
-uv tool install https://github.com/champi-ai/champi-imgui/releases/download/v1.2.0/champi_imgui-1.2.0-py3-none-any.whl
+uv tool install https://github.com/champi-ai/champi-imgui/releases/download/v1.2.1/champi_imgui-1.2.1-py3-none-any.whl
 champi-imgui serve
 
 # Add to a project
-uv add https://github.com/champi-ai/champi-imgui/releases/download/v1.2.0/champi_imgui-1.2.0-py3-none-any.whl
+uv add https://github.com/champi-ai/champi-imgui/releases/download/v1.2.1/champi_imgui-1.2.1-py3-none-any.whl
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The easiest way to use champi-imgui is via the `.mcp.json` config — no install
       "command": "uvx",
       "args": [
         "--from",
-        "https://github.com/champi-ai/champi-imgui/releases/download/v1.2.1/champi_imgui-1.2.1-py3-none-any.whl",
+        "https://github.com/champi-ai/champi-imgui/releases/download/v1.2.0/champi_imgui-1.2.0-py3-none-any.whl",
         "champi-imgui",
         "serve"
       ]
@@ -59,14 +59,14 @@ Install from the GitHub release:
 
 ```bash
 # Run without installing (ephemeral)
-uvx --from https://github.com/champi-ai/champi-imgui/releases/download/v1.2.1/champi_imgui-1.2.1-py3-none-any.whl champi-imgui serve
+uvx --from https://github.com/champi-ai/champi-imgui/releases/download/v1.2.0/champi_imgui-1.2.0-py3-none-any.whl champi-imgui serve
 
 # Install as a persistent tool
-uv tool install https://github.com/champi-ai/champi-imgui/releases/download/v1.2.1/champi_imgui-1.2.1-py3-none-any.whl
+uv tool install https://github.com/champi-ai/champi-imgui/releases/download/v1.2.0/champi_imgui-1.2.0-py3-none-any.whl
 champi-imgui serve
 
 # Add to a project
-uv add https://github.com/champi-ai/champi-imgui/releases/download/v1.2.1/champi_imgui-1.2.1-py3-none-any.whl
+uv add https://github.com/champi-ai/champi-imgui/releases/download/v1.2.0/champi_imgui-1.2.0-py3-none-any.whl
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The easiest way to use champi-imgui is via the `.mcp.json` config — no install
       "command": "uvx",
       "args": [
         "--from",
-        "https://github.com/champi-ai/champi-imgui/releases/download/v1.2.1/champi_imgui-1.2.1-py3-none-any.whl",
+        "https://github.com/champi-ai/champi-imgui/releases/download/v1.3.0/champi_imgui-1.3.0-py3-none-any.whl",
         "champi-imgui",
         "serve"
       ]
@@ -59,14 +59,14 @@ Install from the GitHub release:
 
 ```bash
 # Run without installing (ephemeral)
-uvx --from https://github.com/champi-ai/champi-imgui/releases/download/v1.2.1/champi_imgui-1.2.1-py3-none-any.whl champi-imgui serve
+uvx --from https://github.com/champi-ai/champi-imgui/releases/download/v1.3.0/champi_imgui-1.3.0-py3-none-any.whl champi-imgui serve
 
 # Install as a persistent tool
-uv tool install https://github.com/champi-ai/champi-imgui/releases/download/v1.2.1/champi_imgui-1.2.1-py3-none-any.whl
+uv tool install https://github.com/champi-ai/champi-imgui/releases/download/v1.3.0/champi_imgui-1.3.0-py3-none-any.whl
 champi-imgui serve
 
 # Add to a project
-uv add https://github.com/champi-ai/champi-imgui/releases/download/v1.2.1/champi_imgui-1.2.1-py3-none-any.whl
+uv add https://github.com/champi-ai/champi-imgui/releases/download/v1.3.0/champi_imgui-1.3.0-py3-none-any.whl
 ```
 
 ---


### PR DESCRIPTION
Updates README and `.mcp.json.example` install URLs from v1.2.1 → v1.3.0 (released with numpy dependency).