### PR TITLE
fix: validate filled shapes and unknown shape type strings

### DIFF
--- a/src/champi_imgui/server/main.py
+++ b/src/champi_imgui/server/main.py
@@ -3361,6 +3361,7 @@ def drawing_add_shape(
     radius: float = 50.0,
     color: list[float] | None = None,
     thickness: float = 2.0,
+    filled: bool = False,
 ) -> dict[str, Any]:
     """Add a shape to a drawing widget.
 
@@ -3377,6 +3378,7 @@ def drawing_add_shape(
         radius: Radius for circle in pixels
         color: RGBA color as [r, g, b, a] with values 0.0-1.0 (default blue)
         thickness: Line thickness in pixels
+        filled: Whether the shape is filled (only supported for "rect" and "circle")
 
     Returns:
         Success status and widget identifier
@@ -3388,12 +3390,30 @@ def drawing_add_shape(
         widget = canvas.widget_registry.get(widget_id)
         if not widget:
             return {"success": False, "error": f"Widget {widget_id} not found"}
-        from champi_imgui.widgets.drawing import DrawingWidget
+        from champi_imgui.widgets.drawing import (
+            FILL_SUPPORTED_TYPES,
+            VALID_SHAPE_TYPES,
+            DrawingWidget,
+        )
 
         if not isinstance(widget, DrawingWidget):
             return {
                 "success": False,
                 "error": f"Widget {widget_id} is not a DrawingWidget",
+            }
+        if shape_type not in VALID_SHAPE_TYPES:
+            logger.warning(f"drawing_add_shape: unknown shape type '{shape_type}'")
+            return {"success": False, "error": f"Unknown shape type: '{shape_type}'"}
+        if filled and shape_type not in FILL_SUPPORTED_TYPES:
+            logger.warning(
+                f"drawing_add_shape: shape type '{shape_type}' does not support fill"
+            )
+            return {
+                "success": False,
+                "error": (
+                    f"Shape type '{shape_type}' does not support fill; "
+                    f"only {sorted(FILL_SUPPORTED_TYPES)} do"
+                ),
             }
         color_tuple: tuple[float, float, float, float] = (
             tuple(color) if color else (0.0, 0.5, 1.0, 1.0)  # type: ignore[assignment]
@@ -3403,6 +3423,7 @@ def drawing_add_shape(
                 shape_type,
                 color=color_tuple,
                 thickness=thickness,
+                filled=filled,
                 cx=cx,
                 cy=cy,
                 radius=radius,
@@ -3412,6 +3433,7 @@ def drawing_add_shape(
                 shape_type,
                 color=color_tuple,
                 thickness=thickness,
+                filled=filled,
                 x1=x1,
                 y1=y1,
                 x2=x2,
@@ -3602,7 +3624,8 @@ def drawing_import_strokes(
         canvas_id: Target canvas identifier
         widget_id: DrawingWidget identifier
         strokes: List of strokes to import (each stroke is a list of [x, y] points)
-        shapes: List of shape dicts to import
+        shapes: List of shape dicts to import; each must have a known "type" field
+            and may not set "filled": true for types that do not support fill
         annotations: List of annotation dicts to import
         merge: When False (default) replace existing data; when True append to it
 
@@ -3616,13 +3639,40 @@ def drawing_import_strokes(
         widget = canvas.widget_registry.get(widget_id)
         if not widget:
             return {"success": False, "error": f"Widget {widget_id} not found"}
-        from champi_imgui.widgets.drawing import DrawingWidget
+        from champi_imgui.widgets.drawing import (
+            FILL_SUPPORTED_TYPES,
+            VALID_SHAPE_TYPES,
+            DrawingWidget,
+        )
 
         if not isinstance(widget, DrawingWidget):
             return {
                 "success": False,
                 "error": f"Widget {widget_id} is not a DrawingWidget",
             }
+
+        if shapes is not None:
+            for shape in shapes:
+                stype = shape.get("type", "")
+                if stype not in VALID_SHAPE_TYPES:
+                    logger.warning(
+                        f"drawing_import_strokes: unknown shape type '{stype}'"
+                    )
+                    return {
+                        "success": False,
+                        "error": f"Unknown shape type: '{stype}'",
+                    }
+                if shape.get("filled", False) and stype not in FILL_SUPPORTED_TYPES:
+                    logger.warning(
+                        f"drawing_import_strokes: shape type '{stype}' does not support fill"
+                    )
+                    return {
+                        "success": False,
+                        "error": (
+                            f"Shape type '{stype}' does not support fill; "
+                            f"only {sorted(FILL_SUPPORTED_TYPES)} do"
+                        ),
+                    }
 
         def _apply() -> None:
             props = widget.state.properties

--- a/src/champi_imgui/widgets/drawing.py
+++ b/src/champi_imgui/widgets/drawing.py
@@ -20,6 +20,9 @@ AUTHOR_COLORS: dict[str, tuple[float, float, float, float]] = {
     "llm": (0.0, 0.5, 1.0, 1.0),
 }
 
+VALID_SHAPE_TYPES: frozenset[str] = frozenset({"rect", "circle", "arrow", "line"})
+FILL_SUPPORTED_TYPES: frozenset[str] = frozenset({"rect", "circle"})
+
 
 class DrawingWidget(Widget):
     """Freehand drawing widget with stroke-based undo support.
@@ -333,6 +336,7 @@ class DrawingWidget(Widget):
         shape_type: str,
         color: tuple[float, float, float, float] = (0.0, 0.5, 1.0, 1.0),
         thickness: float = 2.0,
+        filled: bool = False,
         **coords: float,
     ) -> None:
         """Add a shape to the canvas.
@@ -341,13 +345,26 @@ class DrawingWidget(Widget):
             shape_type: One of "rect", "circle", "arrow", "line"
             color: RGBA color tuple (0.0-1.0 range)
             thickness: Line thickness in pixels
+            filled: Whether the shape is filled (only supported for "rect" and "circle")
             **coords: Coordinate arguments. rect/arrow/line use x1, y1, x2, y2;
                 circle uses cx, cy, radius. All values are canvas-relative.
+
+        Raises:
+            ValueError: If shape_type is unknown or filled is True for a type that
+                does not support fill.
         """
+        if shape_type not in VALID_SHAPE_TYPES:
+            raise ValueError(f"Unknown shape type: '{shape_type}'")
+        if filled and shape_type not in FILL_SUPPORTED_TYPES:
+            raise ValueError(
+                f"Shape type '{shape_type}' does not support fill; "
+                f"only {sorted(FILL_SUPPORTED_TYPES)} do"
+            )
         shape: dict[str, Any] = {
             "type": shape_type,
             "color": color,
             "thickness": thickness,
+            "filled": filled,
             **coords,
         }
         shapes: list[dict[str, Any]] = self.state.properties.get("shapes", [])

--- a/tests/test_drawing_mcp_tools.py
+++ b/tests/test_drawing_mcp_tools.py
@@ -775,3 +775,127 @@ class TestDrawingWidgetImportRoundtrip:
         assert len(widget.state.properties.get("strokes", [])) == 1
         assert len(widget.state.properties.get("annotations", [])) == 1
         assert len(widget.state.properties.get("shapes", [])) == 1
+
+
+# ---------------------------------------------------------------------------
+# Shape validation: unknown type and filled on unsupported types
+# ---------------------------------------------------------------------------
+
+
+class TestShapeValidation:
+    @pytest.mark.parametrize("shape_type", ["unknown_blob", "triangle", "", "RECT"])
+    def test_add_shape_unknown_type_returns_error(self, cid, shape_type):
+        """drawing_add_shape returns a structured error for unknown shape types."""
+        _make_canvas_with_drawing(cid)
+
+        result = server.drawing_add_shape.fn(cid, "draw1", shape_type)
+
+        assert result["success"] is False
+        assert f"Unknown shape type: '{shape_type}'" in result["error"]
+
+    @pytest.mark.parametrize("shape_type", ["arrow", "line"])
+    def test_add_shape_filled_unsupported_returns_error(self, cid, shape_type):
+        """drawing_add_shape returns a structured error when filled=True is passed
+        for a shape type that does not support fill."""
+        _make_canvas_with_drawing(cid)
+
+        result = server.drawing_add_shape.fn(
+            cid, "draw1", shape_type, filled=True
+        )
+
+        assert result["success"] is False
+        assert "does not support fill" in result["error"]
+
+    @pytest.mark.parametrize("shape_type", ["rect", "circle"])
+    def test_add_shape_filled_supported_succeeds(self, cid, shape_type):
+        """drawing_add_shape accepts filled=True for rect and circle."""
+        widget = _make_canvas_with_drawing(cid)
+
+        if shape_type == "circle":
+            result = server.drawing_add_shape.fn(
+                cid, "draw1", shape_type, cx=50.0, cy=50.0, radius=20.0, filled=True
+            )
+        else:
+            result = server.drawing_add_shape.fn(
+                cid, "draw1", shape_type, x1=0.0, y1=0.0, x2=50.0, y2=50.0, filled=True
+            )
+
+        assert result["success"] is True
+        shapes = widget.state.properties["shapes"]
+        assert len(shapes) == 1
+        assert shapes[0]["filled"] is True
+
+    def test_add_shape_filled_defaults_to_false(self, cid):
+        """drawing_add_shape stores filled=False on the shape when not specified."""
+        widget = _make_canvas_with_drawing(cid)
+
+        server.drawing_add_shape.fn(cid, "draw1", "rect")
+
+        assert widget.state.properties["shapes"][0]["filled"] is False
+
+    @pytest.mark.parametrize("shape_type", ["unknown_blob", "triangle", "", "RECT"])
+    def test_import_strokes_unknown_shape_type_returns_error(self, cid, shape_type):
+        """drawing_import_strokes returns a structured error for unknown shape types."""
+        _make_canvas_with_drawing(cid)
+        shape = {
+            "type": shape_type,
+            "color": [0.0, 0.5, 1.0, 1.0],
+            "thickness": 2.0,
+            "x1": 0.0,
+            "y1": 0.0,
+            "x2": 10.0,
+            "y2": 10.0,
+        }
+
+        result = server.drawing_import_strokes.fn(cid, "draw1", shapes=[shape])
+
+        assert result["success"] is False
+        assert f"Unknown shape type: '{shape_type}'" in result["error"]
+
+    @pytest.mark.parametrize("shape_type", ["arrow", "line"])
+    def test_import_strokes_filled_unsupported_returns_error(self, cid, shape_type):
+        """drawing_import_strokes returns a structured error when a shape has
+        filled=True for a type that does not support fill."""
+        _make_canvas_with_drawing(cid)
+        shape = {
+            "type": shape_type,
+            "color": [0.0, 0.5, 1.0, 1.0],
+            "thickness": 2.0,
+            "filled": True,
+            "x1": 0.0,
+            "y1": 0.0,
+            "x2": 10.0,
+            "y2": 10.0,
+        }
+
+        result = server.drawing_import_strokes.fn(cid, "draw1", shapes=[shape])
+
+        assert result["success"] is False
+        assert "does not support fill" in result["error"]
+
+    def test_import_strokes_valid_shapes_succeed(self, cid):
+        """drawing_import_strokes accepts a list of valid shapes without errors."""
+        widget = _make_canvas_with_drawing(cid)
+        shapes = [
+            {"type": "rect", "color": [1.0, 0.0, 0.0, 1.0], "thickness": 2.0,
+             "x1": 0.0, "y1": 0.0, "x2": 50.0, "y2": 50.0},
+            {"type": "circle", "color": [0.0, 1.0, 0.0, 1.0], "thickness": 1.0,
+             "cx": 25.0, "cy": 25.0, "radius": 10.0},
+            {"type": "arrow", "color": [0.0, 0.0, 1.0, 1.0], "thickness": 2.0,
+             "x1": 0.0, "y1": 0.0, "x2": 100.0, "y2": 100.0},
+            {"type": "line", "color": [1.0, 1.0, 0.0, 1.0], "thickness": 1.5,
+             "x1": 5.0, "y1": 5.0, "x2": 80.0, "y2": 80.0},
+        ]
+
+        result = server.drawing_import_strokes.fn(cid, "draw1", shapes=shapes)
+
+        assert result["success"] is True
+        assert len(widget.state.properties["shapes"]) == 4
+
+    def test_import_strokes_no_shapes_arg_is_safe(self, cid):
+        """drawing_import_strokes with shapes=None does not raise."""
+        _make_canvas_with_drawing(cid)
+
+        result = server.drawing_import_strokes.fn(cid, "draw1", shapes=None)
+
+        assert result["success"] is True


### PR DESCRIPTION
## Summary

- `VALID_SHAPE_TYPES` and `FILL_SUPPORTED_TYPES` constants added to `drawing.py` to centralise shape type knowledge
- `drawing_add_shape` and `drawing_import_strokes` now return `{"success": false, "error": "..."}` instead of silently dropping when an unknown shape type is supplied or `filled=True` is used with a type that does not support fill (`arrow`, `line`)
- `filled: bool = False` field is now written into every shape dict produced by `add_shape`
- Loguru warnings are emitted before returning the error responses

## Test plan

- [ ] `drawing_add_shape` with unknown type returns `{"success": false, "error": "Unknown shape type: '<type>'"}`
- [ ] `drawing_add_shape` with `filled=True` on `arrow`/`line` returns `{"success": false, "error": "... does not support fill"}`
- [ ] `drawing_add_shape` with `filled=True` on `rect`/`circle` succeeds and stores `filled=True` on the shape dict
- [ ] `drawing_add_shape` without `filled` stores `filled=False` by default
- [ ] `drawing_import_strokes` with an unknown shape type returns the structured error
- [ ] `drawing_import_strokes` with `filled=True` on an unsupported type returns the structured error
- [ ] All 779 existing + new tests pass, coverage ≥ 66%

Closes #91