### PR TITLE
fix: use add_polyline for solid strokes in DrawingWidget

### DIFF
--- a/src/champi_imgui/widgets/drawing.py
+++ b/src/champi_imgui/widgets/drawing.py
@@ -240,8 +240,7 @@ class DrawingWidget(Widget):
                     t = t_end
                     draw = not draw
         else:
-            for i in range(len(pts) - 1):
-                draw_list.add_line(pts[i], pts[i + 1], color_u32, brush_size)
+            draw_list.add_polyline(pts, color_u32, 0, brush_size)  # type: ignore[arg-type]
 
     def _draw_shape(  # pragma: no cover
         self,


### PR DESCRIPTION
## Summary

- Replace the per-segment `add_line` loop with a single `add_polyline` call for solid brush style in `DrawingWidget._draw_stroke`
- More efficient (one draw call per stroke instead of N-1) and eliminates visible gaps at segment joins for thick strokes

## Test plan

- [ ] All 79 existing drawing tests pass
- [ ] `ruff check` and `mypy` clean

Closes #106