### PR TITLE
feat: fall back to AUTHOR_COLORS when stroke has no explicit color

### DIFF
--- a/src/champi_imgui/widgets/drawing.py
+++ b/src/champi_imgui/widgets/drawing.py
@@ -116,14 +116,19 @@ class DrawingWidget(Widget):
             imgui.color_convert_float4_to_u32(imgui.ImVec4(0.15, 0.15, 0.15, 1.0)),
         )
 
-        # Replay all completed strokes
+        # Replay all completed strokes; fall back to AUTHOR_COLORS when no
+        # explicit color is stored (e.g. strokes imported without a color field).
+        _default_color: tuple[float, float, float, float] = (0.1, 0.1, 0.1, 1.0)
         for stroke in strokes:
             points = stroke["points"]
             if len(points) >= 2:
+                stroke_color: tuple[float, float, float, float] = stroke.get(
+                    "color"
+                ) or AUTHOR_COLORS.get(stroke.get("author", ""), _default_color)
                 self._draw_stroke(
                     draw_list,
                     points,
-                    stroke["color"],
+                    stroke_color,
                     stroke["brush_size"],
                     stroke["brush_style"],
                     canvas_min,


### PR DESCRIPTION
## Summary

- When replaying strokes each frame, resolve color as `stroke["color"] or AUTHOR_COLORS.get(author, default)` instead of always reading `stroke["color"]`
- Ensures strokes imported without a color field (but with a known `author`) render with the canonical author hue: LLM strokes blue, user strokes dark
- No change to strokes that already carry an explicit color

## Closed as already implemented
#118 (stroke metadata), #120 (export/import tools), #121 (round-trip + metadata tests)

## Test plan

- [ ] 84 tests pass
- [ ] `ruff check`, `ruff format --check`, `mypy` clean

Closes #119