### PR TITLE
fix(ipc): explicit little-endian structs + ARM64 alignment fix

### DIFF
--- a/docs/phases/phase-champi-ai-cli-foundation.md
+++ b/docs/phases/phase-champi-ai-cli-foundation.md
@@ -1,0 +1,57 @@
+# Phase: champi-ai-cli Foundation
+
+## Goal
+A new `champi-ai-cli` package exists with a working CLI, orchestrator, and Claude adapter that can wire champi-imgui + champi-stt + champi-tts into a single coordinated session.
+
+## Deliverables
+
+### Backend
+- [ ] New repo: `champi-ai/champi-ai-cli` with `src/champi_ai_cli/` package layout
+- [ ] `cli.py`: Click-based CLI with subcommands: `start`, `status`, `discover`, `canvas`
+- [ ] `orchestrator.py`: `ChampiOrchestrator` that subscribes to ImgUIEventTypes, STT, and TTS event lanes via champi-signals; dispatches to registered handlers; maintains session state (open canvases, active streams)
+- [ ] `adapters/base.py`: `ModelAdapter` ABC with methods `on_tool_call_start`, `on_canvas_update`, `on_speech`, `respond`
+- [ ] `adapters/claude.py`: `ClaudeAdapter` implementation using Anthropic SDK
+- [ ] `adapters/openai.py`: `OpenAIAdapter` stub (interface only, raises NotImplementedError)
+- [ ] `examples/jarvis_demo.py`: wires champi-imgui canvas (chat UI) + champi-stt (WhisperLive) + champi-tts (Kokoro) via ChampiOrchestrator + ClaudeAdapter; wake word "hey champi"
+
+### Infrastructure
+- [ ] `pyproject.toml` with dependencies: `click`, `champi-signals`, `champi-ipc`, `champi-imgui`, `anthropic`
+- [ ] Dev dependencies: `pytest`, `ruff`, `mypy`
+- [ ] CI workflow (GitHub Actions): lint + type check + test
+- [ ] `champi-cli` entry point in pyproject.toml
+
+### Validation
+- [ ] Unit tests for ChampiOrchestrator event dispatch (mocked signal lanes)
+- [ ] Unit tests for ClaudeAdapter (mocked Anthropic SDK)
+- [ ] CLI smoke test: `champi-cli --help` returns 0
+- [ ] Integration test: orchestrator discovers a running champi-imgui canvas via RENDER_FRAME lane
+
+## Done Definition
+- `pip install champi-ai-cli` installs the package and `champi-cli` is on PATH
+- `champi-cli start` launches champi-imgui with signals wired
+- `champi-cli status` queries running actors via health lanes and prints results
+- `champi-cli discover` prints active lane registrations
+- `ChampiOrchestrator.on_event(event_type, handler)` correctly dispatches events to registered handlers
+- `ClaudeAdapter` sends prompts to Anthropic API and routes responses to TTS + canvas
+- `jarvis_demo.py` runs end-to-end with all three champi packages installed
+
+## Parallel work
+- BE: `ModelAdapter` ABC + `ClaudeAdapter` can be written in parallel with `ChampiOrchestrator`
+- BE: CLI subcommands can be stubbed immediately while orchestrator internals are built
+- INFRA: pyproject.toml + CI can be set up day 1 while all BE work proceeds
+
+## Phase dependencies
+- Requires: Phase: MCP Render Fix (RENDER_FRAME heartbeat for health monitoring)
+- Requires: Phase: MCP System State Reporter (ImgUISignalManager, QUERY_STATE/STATE_RESPONSE for status/discover commands)
+- Requires: champi-signals and champi-ipc to be published/installable
+
+## Complexity
+- Backend: L
+- Frontend: N/A
+- Infra: M
+
+## Risks
+- champi-stt and champi-tts signal integration may not be stable yet; Jarvis demo may need to stub those initially
+- Anthropic SDK async patterns may conflict with champi-signals' synchronous event dispatch; may need an async bridge
+- New repo bootstrap means no existing CI, tests, or linting — higher initial overhead
+- The orchestrator's "discover" feature depends on champi-ipc lane registry, which may not expose a discovery API yet

--- a/docs/phases/phase-ipc-prerequisite.md
+++ b/docs/phases/phase-ipc-prerequisite.md
@@ -1,0 +1,53 @@
+# Phase: IPC Prerequisite
+
+## Goal
+The IPC command layer correctly separates title and size updates, uses explicit cross-platform struct layout, and produces correct values on all supported architectures (x86-64 and ARM64 / Apple Silicon).
+
+## Deliverables
+
+### Backend
+- [ ] Fix `unpack_command` in `ipc/structs.py` to handle `UPDATE_TITLE` and `UPDATE_SIZE` (remove stale `UPDATE_STATE` / `UPDATE_STATE_STRUCT` references)
+- [ ] Update `_process_ipc_command` in `core/canvas.py` to dispatch `UPDATE_TITLE` and `UPDATE_SIZE` separately (remove `UPDATE_STATE` handler)
+- [ ] Add `_handle_update_title` and `_handle_update_size` methods to Canvas
+- [ ] Update `update_canvas_state` MCP tool in `server/main.py` to send `UPDATE_TITLE` when only title changes, `UPDATE_SIZE` when only size changes, or both commands sequentially when both change
+- [ ] Remove all remaining references to `CommandType.UPDATE_STATE` across the codebase
+
+### Infrastructure
+- [ ] Add `[project.optional-dependencies] ecosystem` to `pyproject.toml` with `champi-signals` and `champi-ipc` as optional deps
+- [ ] Add `HAS_ECOSYSTEM` import guard pattern to a shared utils module for reuse in later phases
+
+### Cross-platform struct fix (Apple Silicon / ARM64)
+- [ ] Change all struct format strings in `ipc/structs.py` from `=` (native byte order) to `<` (explicit little-endian) to guarantee consistent wire format across Linux x86-64 and macOS ARM64
+- [ ] Add 3 explicit padding bytes (`3x`) before the `II` fields in `UPDATE_SIZE_STRUCT` so integer fields land on 4-byte-aligned offsets (offset 73 → 76) — fixes incorrect width/height reads on strict-alignment architectures
+- [ ] Add a round-trip pack/unpack test for `UPDATE_SIZE_STRUCT` asserting exact `width` and `height` values survive serialization
+
+### Validation
+- [ ] All existing tests pass (`uv run pytest`)
+- [ ] Linting and type checks pass (`uv run ruff check src/` and `uv run mypy src/`)
+- [ ] Manual test: `update_canvas_state(canvas_id, title="New Title")` does not reset canvas size
+- [ ] Manual test: `update_canvas_state(canvas_id, width=1024, height=768)` does not blank the title
+- [ ] Round-trip test passes: pack then unpack `UPDATE_SIZE` yields identical width and height on both x86-64 and ARM64
+
+## Done Definition
+- No references to `UPDATE_STATE` or `UPDATE_STATE_STRUCT` remain in `src/`
+- `CommandType` enum has `UPDATE_TITLE = 3`, `UPDATE_SIZE = 4`, `SHUTDOWN = 5` (already correct in command_types.py)
+- `update_canvas_state` MCP tool sends the correct minimal command(s) based on which parameters are provided
+- `pyproject.toml` has `ecosystem` optional-dependencies group
+- All existing tests pass without modification (or with minimal test updates if tests directly referenced `UPDATE_STATE`)
+
+## Parallel work
+- BE: structs.py + canvas.py IPC fix can run alongside INFRA: pyproject.toml ecosystem extras
+- BE: server/main.py tool update can start once structs.py pack/unpack is done
+
+## Phase dependencies
+- Requires: none (this is the prerequisite for both MCP Render Fix and MCP System State Reporter)
+
+## Complexity
+- Backend: S
+- Frontend: N/A
+- Infra: S
+
+## Risks
+- The `unpack_command` function in structs.py currently references `UPDATE_STATE_STRUCT` which does not exist as a defined struct (it was renamed but the unpack path was not updated). This is a latent bug that will cause a `NameError` at runtime if any IPC message with command type 3 is received through the unpack path.
+- Existing tests may assert on `UPDATE_STATE` by name. These need updating but the scope is small.
+- Adding padding bytes to `UPDATE_SIZE_STRUCT` changes the wire format (total size 81 → 84 bytes). Since shared memory regions are re-created fresh on each process start, this is not a rolling-upgrade concern. All consumers must be updated atomically (they are in the same repo).

--- a/docs/phases/phase-mcp-render-fix.md
+++ b/docs/phases/phase-mcp-render-fix.md
@@ -1,0 +1,51 @@
+# Phase: MCP Render Fix
+
+## Goal
+Canvas windows created via the MCP server render successfully, with ecosystem-aligned health monitoring and structured error surfacing.
+
+## Deliverables
+
+### Backend
+- [ ] Store last render-thread exception on Canvas instance (`_render_error: Exception | None`)
+- [ ] Add `is_render_healthy()` method to Canvas: checks `_render_thread.is_alive()` + reports stored exception
+- [ ] Emit `RENDER_FRAME` (ImgUIEventTypes=130) via `SignalProcessor` after each rendered frame in `_render_frame()` (ecosystem path only, guarded by `HAS_ECOSYSTEM`)
+- [ ] `create_canvas` MCP tool: poll RENDER_FRAME ACK region (2s timeout) before returning success (ecosystem path); fallback to 0.5s sleep (standalone)
+- [ ] Add `get_render_error(canvas_id)` MCP tool returning stored render-thread exception
+- [ ] Add `get_render_health(canvas_id)` MCP tool returning `thread_alive`, `ack_lag_seconds` (ecosystem), `last_error`
+- [ ] RENDER_FRAME struct: `seq_num (Q) + canvas_id (64s)`
+
+### Infrastructure
+- [ ] Log `DISPLAY`, `WAYLAND_DISPLAY`, `XDG_SESSION_TYPE`, `LIBGL_ALWAYS_SOFTWARE` at MCP server startup
+- [ ] Add diagnostic script `scripts/diagnose_mcp_render.py`: launches MCP server in-process, calls `create_canvas`, waits 3s, reports thread health + RENDER_FRAME ACK lag (ecosystem) + env vars + last_error
+- [ ] Document required env vars for systemd/supervisor launchers in script docstring
+
+### Validation
+- [ ] Integration test `tests/test_mcp_render.py`: spawn MCP server, call `create_canvas`, call `screenshot_canvas`, assert PNG bytes within 5s
+- [ ] Assert `RENDER_FRAME` ACK increments (ecosystem path, skipped when no ecosystem)
+
+## Done Definition
+- `create_canvas` via MCP returns success AND the render thread is confirmed alive after 1 second
+- `screenshot_canvas` via MCP returns valid PNG data (non-empty, valid header) within 5 seconds of canvas creation
+- Render thread crash is surfaced via `get_render_error` (no silent failures)
+- `get_render_health` returns `ack_lag_seconds` when ecosystem packages are installed, `null` otherwise
+- The diagnostic script runs without error (documents skip for headless-only environments)
+- All existing tests continue to pass
+
+## Parallel work
+- BE: error surfacing + health check method can run alongside INFRA: env logging + diagnostic script
+- BE: `get_render_health` tool can be written alongside RENDER_FRAME signal emission (they share the struct definition but are otherwise independent)
+- BE: integration test can be written in parallel with the fix (test defines acceptance gate, fix makes it pass)
+
+## Phase dependencies
+- Requires: Phase: IPC Prerequisite (ecosystem extras in pyproject.toml, HAS_ECOSYSTEM guard pattern)
+
+## Complexity
+- Backend: M
+- Frontend: N/A
+- Infra: S
+
+## Risks
+- Root cause may be deeper than environment variables (e.g., OpenGL context cannot be created on a daemon thread in some drivers) — may require spawning the render in a subprocess instead of a thread
+- Wayland sessions may not support `glfw.get_x11_window()` at all, requiring an alternative screenshot path (already partially addressed by the OpenGL screenshot fallback)
+- CI environments are headless — the integration test may need Xvfb or a virtual framebuffer, adding infra complexity
+- RENDER_FRAME emission adds per-frame overhead; must be lightweight (single shm write, no allocation)

--- a/docs/phases/phase-mcp-system-state.md
+++ b/docs/phases/phase-mcp-system-state.md
@@ -1,0 +1,63 @@
+# Phase: MCP System State Reporter
+
+## Goal
+A single MCP tool call returns the full internal state of all champi-imgui subsystems, with ecosystem-aligned IPC for cross-process state queries.
+
+## Deliverables
+
+### Backend
+- [ ] New file `src/champi_imgui/signals/manager.py`: `ImgUISignalManager(BaseSignalManager)` wiring blinker signals to ImgUIEventTypes lanes via SignalProcessor (ecosystem path only)
+  - `widget_created` -> `WIDGET_CREATE = 120`
+  - `widget_updated` -> `WIDGET_CREATE = 120` (update path)
+  - `widget_deleted` -> `WIDGET_DELETE = 121`
+  - `canvas_updated` -> `CANVAS_UPDATE = 110`
+- [ ] Add `QUERY_STATE = 140` and `STATE_RESPONSE = 141` to ImgUIEventTypes in champi-signals (PR to champi-signals repo)
+- [ ] Canvas SignalReader subscribes to QUERY_STATE; on receipt serializes `canvas.state.to_dict()` + render diagnostics -> writes to STATE_RESPONSE lane (ecosystem path)
+- [ ] `get_canvas_diagnostics(canvas_id)` MCP tool: writes QUERY_STATE, blocks on STATE_RESPONSE (2s timeout); fallback to direct Python attribute reads (standalone)
+- [ ] Add `to_diagnostics() -> dict` to each manager (use enum `.value`, no string literals):
+  - AnimationManager: `AnimationState.value`, `EasingFunction.value`
+  - NotificationManager: `NotificationType.value`
+  - LayoutManager: `LayoutMode.value`
+  - DataStore: key count, signal path count, per-path receiver counts
+  - BindingManager: binding count, paths list
+  - TemplateManager: saved template names
+  - ThemeManager: current theme name, available theme names
+  - EventQueue: `pending_count`, `subscription_count` (direct from internal state)
+- [ ] Add `get_system_state` MCP tool with structured response: version, uptime_seconds, canvas_count, canvases, managers, ipc_health (ecosystem only), signals (blinker receiver counts)
+- [ ] Add server uptime tracking (start time recorded at module load)
+- [ ] Apply `@EventProcessor.emits_event` decorator to high-value manager methods (AnimationManager.start_animation, etc.) when ecosystem is available
+
+### Validation
+- [ ] Unit tests for `to_diagnostics()` on each manager with real instances
+- [ ] Unit tests for `get_system_state` tool with mocked managers
+- [ ] Unit tests for `get_canvas_diagnostics` tool with mocked STATE_RESPONSE
+- [ ] Unit tests for ImgUISignalManager wiring (verify `connect_signal` calls)
+- [ ] All existing tests continue to pass
+- [ ] mypy, ruff check, and ruff format pass
+
+## Done Definition
+- `get_system_state` returns a dict with keys: `version`, `uptime_seconds`, `canvas_count`, `canvases`, `managers`, `ipc_health` (ecosystem), `signals`
+- `get_canvas_diagnostics(canvas_id)` returns: `canvas_id`, `title`, `size`, `running`, `window_id`, `render_thread_alive`, `widget_count`, `widget_count_by_type`, `pending_screenshot`, `pending_measure_text`, `pending_canvas_info`
+- Both tools return `{"success": False, "error": ...}` on invalid input
+- `to_diagnostics()` methods use enum `.value` for all enum fields (no string literals)
+- ImgUISignalManager correctly bridges blinker signals to champi-signals lanes (verified by unit test)
+
+## Parallel work
+- BE: `to_diagnostics()` helpers on AnimationManager, NotificationManager, DataStore, BindingManager, EventQueue can all be written in parallel (independent modules)
+- BE: `ImgUISignalManager` can be written in parallel with `to_diagnostics()` helpers
+- BE: Unit tests can start as soon as tool signatures are defined (stubs first)
+
+## Phase dependencies
+- Requires: Phase: IPC Prerequisite (ecosystem extras, HAS_ECOSYSTEM guard)
+- Requires: Phase: MCP Render Fix (RENDER_FRAME heartbeat for ipc_health reporting, `_render_error` for canvas diagnostics)
+
+## Complexity
+- Backend: M
+- Frontend: N/A
+- Infra: N/A
+
+## Risks
+- Thread safety: reading `_running`, `_render_thread.is_alive()`, and pending request slots from the MCP thread while the render thread may be mutating them. Mitigation: simple attribute reads on immutable/atomic Python objects; no locking needed for read-only diagnostics.
+- AnimationManager.animations dict could be mutated during iteration if an animation completes mid-read. Mitigation: snapshot with `dict(self.animations)` before summarizing.
+- QUERY_STATE / STATE_RESPONSE lanes require a champi-signals PR. If that PR is delayed, the standalone fallback (direct Python reads) still delivers full functionality.
+- `@EventProcessor.emits_event` decorator may have import-time side effects if ecosystem is not installed. Guard with `HAS_ECOSYSTEM` check.

--- a/docs/review/senior-review.md
+++ b/docs/review/senior-review.md
@@ -1,0 +1,39 @@
+# Senior Review
+
+## VERDICT: APPROVED
+
+## Summary
+
+Both specs are well-scoped and internally consistent. The approach is sound for the champi ecosystem.
+
+## Phase A: MCP Render Fix — no blocking issues
+
+- Splitting UPDATE_STATE into UPDATE_TITLE + UPDATE_SIZE is the correct fix for the silent size-reset bug. Enum renumbering (SHUTDOWN 4→5) is safe since this is internal IPC.
+- RENDER_FRAME heartbeat via champi-ipc lane is the correct health check. `_render_thread.is_alive()` was insufficient and this replaces it properly.
+- `HAS_ECOSYSTEM` fallback pattern ensures standalone usage is not broken.
+- 2s timeout for RENDER_FRAME ACK on `create_canvas` is reasonable; will surface the DISPLAY propagation root cause clearly.
+
+## Phase B: MCP System State Reporter — no blocking issues
+
+- `to_diagnostics()` helpers are straightforward and appropriately scoped (5-15 lines each).
+- QUERY_STATE/STATE_RESPONSE lane pattern is the correct actor-boundary approach — reading Canvas state directly from the MCP thread would violate the lane model.
+- Adding QUERY_STATE=140 and STATE_RESPONSE=141 to champi-signals is a cross-repo change; must be done first as a prerequisite.
+- `@EventProcessor.emits_event` decoration is additive and non-breaking.
+
+## Phase C: champi-ai-cli Foundation — no blocking issues
+
+- Scope is appropriately narrow for a foundation phase: CLI, orchestrator, one working adapter, Jarvis demo.
+- `ModelAdapter` ABC is the right abstraction for model-agnostic operation.
+- The Jarvis demo is a concrete acceptance gate for the whole phase.
+- champi-ai-cli depends on champi-imgui phases A and B being done first (health lanes must exist for orchestrator to query).
+
+## Non-blocking notes
+
+- Phase C depends on phases A and B being complete — schedule accordingly.
+- champi-signals QUERY_STATE/STATE_RESPONSE must be PR'd and merged before phase B can implement the Canvas lane handler.
+- The ecosystem optional extras in pyproject.toml use path references (`../champi-signals`) which work locally but will need PyPI references for production. Acceptable for this foundation phase.
+
+## Labels to apply
+
+- champi-imgui: `enhancement`, `ipc`, `mcp`
+- champi-ai-cli: `new-package`, `ecosystem`

--- a/docs/specs/backend.md
+++ b/docs/specs/backend.md
@@ -1,0 +1,306 @@
+# Backend Specification: Finish champi-imgui + Ecosystem Integration
+
+## Project Overview
+
+champi-imgui (v1.16.1) is an ImGui-based MCP server and UI framework for LLM-driven UI generation. It is part of the champi-ai ecosystem:
+
+- **champi-ipc** (v0.1.0) — generic POSIX shared-memory IPC, one shm lane per `IntEnum` value
+- **champi-signals** (v0.1.0) — blinker wrapper, `BaseSignalManager`, `EventProcessor` decorators, `ImgUIEventTypes(IntEnum)`
+- **champi-stt** — multi-provider STT, already uses champi-signals
+- **champi-tts** — multi-provider TTS, already uses champi-signals
+- **champi-imgui** — NOT yet using champi-ipc/champi-signals (uses hand-rolled single-channel IPC)
+
+Existing open milestones: Phase: MCP Render Fix (#15) and Phase: MCP System State Reporter (#16).
+
+---
+
+## Section 1: Prerequisite — IPC Internal Cleanup
+
+### 1.1 Split UPDATE_STATE command
+
+**Problem**: `CommandType.UPDATE_STATE = 3` encodes title + width + height in a single struct with defaults `width=800, height=600`. A title-only update silently resets canvas size.
+
+**Fix**: Split into two minimal commands:
+- `UPDATE_TITLE = 3` — struct: `seq_num + cmd_type + canvas_id + title`
+- `UPDATE_SIZE = 4` — struct: `seq_num + cmd_type + canvas_id + width + height`
+- `SHUTDOWN` moves from 4 → 5
+
+**Files**: `ipc/command_types.py`, `ipc/structs.py`, `core/canvas.py`, `server/main.py`
+
+### 1.2 Add optional ecosystem extras
+
+```toml
+[project.optional-dependencies]
+ecosystem = [
+    "champi-signals @ ../champi-signals",
+    "champi-ipc @ ../champi-ipc",
+]
+```
+
+Standalone fallback pattern in all ecosystem-aware modules:
+```python
+try:
+    from champi_signals import BaseSignalManager
+    from champi_ipc.core.signal_processor import SignalProcessor
+    HAS_ECOSYSTEM = True
+except ImportError:
+    HAS_ECOSYSTEM = False
+```
+
+---
+
+## Section 2: Phase A — MCP Render Fix (Ecosystem-Aligned)
+
+### Problem
+Canvas windows created via the MCP server never render. The render thread starts but `hello_imgui.run()` silently fails because `DISPLAY` / `XAUTHORITY` env vars are not propagated to the MCP server process. The existing `_render_thread.is_alive()` check does not detect a non-rendering render thread.
+
+### 2.1 RENDER_FRAME heartbeat lane
+
+`ImgUIEventTypes.RENDER_FRAME = 130` is already defined in champi-signals.
+
+- In `core/canvas.py`, `_render_frame()` (the hello_imgui show_gui callback): emit `RENDER_FRAME` via `SignalProcessor` after each rendered frame (when `HAS_ECOSYSTEM`)
+- Struct for RENDER_FRAME lane: `seq_num (Q) + canvas_id (64s)`
+- MCP server's `SignalReader` subscribes to RENDER_FRAME per canvas; ACK lag > 2s threshold → render dead
+- `create_canvas` polls RENDER_FRAME ACK region (2s timeout) before returning success
+
+Standalone fallback (no ecosystem): `create_canvas` returns after 0.5s sleep (existing behavior).
+
+### 2.2 Env var propagation
+
+- Log `DISPLAY`, `WAYLAND_DISPLAY`, `XDG_SESSION_TYPE`, `LIBGL_ALWAYS_SOFTWARE` at MCP server startup
+- Document required env vars for systemd/supervisor launchers
+
+### 2.3 Error surfacing
+
+- Store last render-thread exception on Canvas instance (`_render_error: Exception | None`)
+- `get_render_error(canvas_id)` MCP tool returns stored exception for a given canvas
+- `get_render_health(canvas_id)` MCP tool reports: `thread_alive`, `ack_lag_seconds` (ecosystem), `last_error`
+
+### 2.4 Diagnostic script
+
+`scripts/diagnose_mcp_render.py`:
+- Launches MCP server in-process
+- Calls `create_canvas`, waits 3s
+- Reports: thread health, RENDER_FRAME ACK lag (ecosystem), env vars, last_error
+
+### 2.5 Integration test
+
+`tests/test_mcp_render.py`:
+- Spawn MCP server, call `create_canvas`, call `screenshot_canvas`, assert PNG bytes within 5s
+- Assert `RENDER_FRAME` ACK increments (ecosystem path)
+
+---
+
+## Section 3: Phase B — MCP System State Reporter (Ecosystem-Aligned)
+
+### 3.1 ImgUISignalManager
+
+New file: `src/champi_imgui/signals/manager.py`
+
+```python
+from champi_signals import BaseSignalManager
+from champi_signals.enums import ImgUIEventTypes
+
+class ImgUISignalManager(BaseSignalManager):
+    ...
+```
+
+Wire existing blinker signals to ImgUIEventTypes lanes via SignalProcessor:
+- `widget_created` → `WIDGET_CREATE = 120`
+- `widget_updated` → `WIDGET_CREATE = 120` (update path)
+- `widget_deleted` → `WIDGET_DELETE = 121`
+- `canvas_updated` → `CANVAS_UPDATE = 110`
+
+### 3.2 QUERY_STATE / STATE_RESPONSE lanes
+
+Add to `ImgUIEventTypes` in `../champi-signals/src/champi_signals/enums.py`:
+```python
+QUERY_STATE    = 140   # MCP → Canvas: request state snapshot
+STATE_RESPONSE = 141   # Canvas → MCP: deliver state snapshot
+```
+
+- Canvas `SignalReader` subscribes to `QUERY_STATE`; on receipt serialises `canvas.state.to_dict()` + render diagnostics → writes to `STATE_RESPONSE` lane
+- `get_canvas_diagnostics(canvas_id)` writes QUERY_STATE, blocks on STATE_RESPONSE (2s timeout)
+- Fallback (no ecosystem): direct Python attribute reads on Canvas (existing behavior)
+
+### 3.3 Manager `to_diagnostics()` helpers
+
+Add `to_diagnostics() -> dict` to each manager. Must use enum `.value` (no string literals):
+- `AnimationManager`: `AnimationState.value`, `EasingFunction.value`
+- `NotificationManager`: `NotificationType.value`
+- `LayoutManager`: `LayoutMode.value`
+- `DataStore`: key count, signal path count, per-path receiver counts
+- `BindingManager`: binding count, paths list
+- `TemplateManager`: saved template names
+- `ThemeManager`: current theme name, available theme names
+- `EventQueue`: `pending_count`, `subscription_count` (direct from internal state)
+
+### 3.4 `get_system_state` MCP tool
+
+Response shape:
+```python
+{
+    "success": True,
+    "data": {
+        "version": "1.16.1",
+        "uptime_seconds": 142.7,
+        "canvas_count": 2,
+        "canvases": [...],           # from STATE_RESPONSE lanes (ecosystem) or Python reads
+        "managers": {
+            "animations": {...},
+            "data_store": {"key_count": N, "signal_paths": [...]},
+            "bindings": {"binding_count": N, "paths": [...]},
+            "notifications": {"queued_count": N, "recent": [...]},
+            "layout": {"mode": "free"},
+            "templates": {"saved": [...]},
+            "themes": {"current": "dark", "available": [...]}
+        },
+        "ipc_health": {              # only when HAS_ECOSYSTEM
+            "render_frame_ack_lag": {...},
+            "widget_create_queue_depth": N
+        },
+        "signals": {                 # blinker receiver counts
+            "widget_created": N,
+            "widget_updated": N,
+            "canvas_updated": N
+        }
+    }
+}
+```
+
+### 3.5 `get_canvas_diagnostics` MCP tool
+
+Response shape:
+```python
+{
+    "success": True,
+    "data": {
+        "canvas_id": "main",
+        "title": "Main Canvas",
+        "size": [800, 600],
+        "running": True,
+        "window_id": 12345678,
+        "render_thread_alive": True,
+        "widget_count": 12,
+        "widget_count_by_type": {"ButtonWidget": 3, "TextWidget": 5},
+        "pending_screenshot": False,
+        "pending_measure_text": False,
+        "pending_canvas_info": False
+    }
+}
+```
+
+### 3.6 `@EventProcessor.emits_event` on manager methods
+
+Apply to high-value manager methods:
+```python
+from champi_signals.processors import EventProcessor
+
+class AnimationManager:
+    @EventProcessor.emits_event(data=["animations"])
+    def start_animation(self, ...): ...
+```
+
+### 3.7 Unit tests
+
+- `to_diagnostics()` on each manager with mocked/real instances
+- `get_system_state` tool with mocked managers
+- `get_canvas_diagnostics` tool with mocked STATE_RESPONSE
+- ImgUISignalManager wiring (verify `connect_signal` calls)
+
+---
+
+## Section 4: Phase C — champi-ai-cli Foundation
+
+### Vision
+
+champi-ai-cli is the agnostic AI orchestration layer that ties the champi ecosystem together. It is NOT an MCP wrapper — it is an edge-first, model-agnostic framework that removes the constraints of current LLM systems:
+
+- **Programs as persistent actors**: A running champi-imgui canvas IS the program. Identity (canvas_id) survives sessions. The meta-system definition (lane topology, widget schemas, data bindings) is the durable artifact.
+- **Interface discovery over interface description**: Actors publish their capabilities via lanes. The orchestrator discovers what's running, not what was described.
+- **No context-window-as-only-state-store**: State lives in POSIX shm, in running processes, in canvas widget registries — not in LLM memory.
+- **MCP as compatibility adaptor**: champi-imgui's MCP server exists to show integration with existing LLM tooling, not as the primary integration path.
+
+### 4.1 CLI entry point
+
+Package: `champi-ai-cli`
+Module: `champi_ai_cli`
+
+```
+champi-cli start      # Start all champi services (imgui, stt, tts) with shared signal manager
+champi-cli status     # Query all running actors via their RENDER_FRAME / health lanes
+champi-cli discover   # Print all active lane registrations
+champi-cli canvas     # Open an imgui canvas with champi-signals wired
+```
+
+### 4.2 Orchestrator actor
+
+`champi_ai_cli/orchestrator.py`:
+- `ChampiOrchestrator`: subscribes to all ImgUIEventTypes lanes, all STT event lanes, all TTS event lanes
+- Dispatches events to registered handlers (model adapters)
+- Maintains session state: which canvases are open, which STT/TTS streams are active
+- Exposes a simple `on_event(event_type, handler)` API for model adapters
+
+### 4.3 Model adapter interface
+
+```python
+class ModelAdapter(ABC):
+    async def on_tool_call_start(self, event: ToolCallEvent) -> None: ...
+    async def on_canvas_update(self, event: CanvasUpdateEvent) -> None: ...
+    async def on_speech(self, text: str) -> None: ...
+    async def respond(self, text: str) -> None: ...
+```
+
+Built-in adapters: `ClaudeAdapter` (uses Anthropic SDK), `OpenAIAdapter`.
+
+### 4.4 Jarvis demo
+
+`examples/jarvis_demo.py`:
+- Starts champi-imgui canvas with a chat UI
+- Starts champi-stt with WhisperLive backend
+- Starts champi-tts with Kokoro backend
+- Wires everything via ChampiOrchestrator + ClaudeAdapter
+- Wake word "hey champi" → STT active → LLM response → TTS speaks + canvas updates
+
+### 4.5 Package structure
+
+```
+src/champi_ai_cli/
+├── __init__.py
+├── cli.py                   # Click CLI entry points
+├── orchestrator.py          # ChampiOrchestrator
+├── adapters/
+│   ├── __init__.py
+│   ├── base.py              # ModelAdapter ABC
+│   ├── claude.py            # ClaudeAdapter
+│   └── openai.py            # OpenAIAdapter (stub)
+└── examples/
+    └── jarvis_demo.py
+```
+
+---
+
+## API Contracts (Section 7 — for spec-backend alignment)
+
+### New MCP tools
+
+| Tool | Input | Output |
+|------|-------|--------|
+| `get_render_health(canvas_id)` | `canvas_id: str` | `{thread_alive, ack_lag_seconds, last_error}` |
+| `get_render_error(canvas_id)` | `canvas_id: str` | `{error: str \| null}` |
+| `get_system_state()` | none | structured dict (see §3.4) |
+| `get_canvas_diagnostics(canvas_id)` | `canvas_id: str` | structured dict (see §3.5) |
+
+### Modified MCP tools
+
+| Tool | Change |
+|------|--------|
+| `update_canvas_state` | Uses UPDATE_TITLE or UPDATE_SIZE command, never combined |
+| `create_canvas` | Waits for RENDER_FRAME ACK before returning success (ecosystem path) |
+
+### New signals (champi-signals)
+
+| Signal | Value | Direction |
+|--------|-------|-----------|
+| `QUERY_STATE` | 140 | MCP → Canvas |
+| `STATE_RESPONSE` | 141 | Canvas → MCP |

--- a/docs/specs/frontend.md
+++ b/docs/specs/frontend.md
@@ -1,0 +1,24 @@
+# Frontend Specification: N/A
+
+This project is a Python library (champi-imgui) with a CLI entry point. There is no web frontend.
+The "frontend" from the LLM perspective is the MCP tool API and the ImGui canvas windows.
+
+## MCP Tool API (Section 7 — API Contract)
+
+All existing MCP tools are documented in `docs/MCP_TOOLS_API.md`.
+
+New tools added by the completion phases are specified in `docs/specs/backend.md` Section 7.
+
+## ImGui Canvas (visual output)
+
+ImGui canvas windows are created and managed by the champi-imgui MCP server. The visual output is
+the canvas window rendered by hello_imgui on the user's display. No web frontend is involved.
+
+## champi-ai-cli UX
+
+The `champi-cli` command-line interface is the human-facing entry point for the ecosystem.
+It is a Click CLI — no web UI. The Jarvis demo (`examples/jarvis_demo.py`) uses:
+- champi-imgui canvas as the visual UI
+- champi-stt for voice input
+- champi-tts for voice output
+- ChampiOrchestrator as the coordination layer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,16 +53,15 @@ dev = [
 ]
 
 # Ecosystem integration (champi-signals + champi-ipc)
+# Install with: uv sync --extra ecosystem
 ecosystem = [
-    "champi-signals @ ../champi-signals",
-    "champi-ipc @ ../champi-ipc",
+    "champi-signals",
+    "champi-ipc",
 ]
 
-# All features
+# All features (ecosystem extras installed separately: uv sync --extra ecosystem)
 all = [
     "champi-imgui[dev]",
-    "champi-signals @ ../champi-signals",
-    "champi-ipc @ ../champi-ipc",
 ]
 
 [project.urls]
@@ -85,6 +84,10 @@ allow-direct-references = true
 package = true
 no-build-isolation = false
 managed = true
+
+[tool.uv.sources]
+champi-signals = { path = "../champi-signals" }
+champi-ipc = { path = "../champi-ipc" }
 
 # Ruff configuration
 [tool.ruff]

--- a/src/champi_imgui/ipc/structs.py
+++ b/src/champi_imgui/ipc/structs.py
@@ -20,31 +20,33 @@ MAX_WIDGET_TYPE_SIZE = 32
 PAD_CHAR = b"#"
 
 # Struct definitions
-# Format: '=' (native byte order), 'Q' (8-byte unsigned long), 'B' (1-byte unsigned char)
-HEADER_STRUCT = struct.Struct("=QB")  # seq_num + command_type
+# Explicit little-endian ('<') ensures consistent wire format on x86-64 and ARM64 (Apple Silicon).
+# '3x' before II pads to 4-byte alignment (offset 73 → 76) so integer fields never
+# land on a misaligned boundary on strict-alignment architectures.
+HEADER_STRUCT = struct.Struct("<QB")  # seq_num + command_type
 
 CLEAR_CANVAS_STRUCT = struct.Struct(
-    f"=QB{MAX_CANVAS_ID_SIZE}s"
+    f"<QB{MAX_CANVAS_ID_SIZE}s"
 )  # seq_num + cmd_type + canvas_id
 
 UPDATE_TITLE_STRUCT = struct.Struct(
-    f"=QB{MAX_CANVAS_ID_SIZE}s{MAX_TITLE_SIZE}s"
+    f"<QB{MAX_CANVAS_ID_SIZE}s{MAX_TITLE_SIZE}s"
 )  # seq_num + cmd_type + canvas_id + title
 
 UPDATE_SIZE_STRUCT = struct.Struct(
-    f"=QB{MAX_CANVAS_ID_SIZE}sII"
-)  # seq_num + cmd_type + canvas_id + width + height
+    f"<QB{MAX_CANVAS_ID_SIZE}s3xII"
+)  # seq_num + cmd_type + canvas_id + (3 pad bytes) + width + height
 
 SHUTDOWN_STRUCT = struct.Struct(
-    f"=QB{MAX_CANVAS_ID_SIZE}s"
+    f"<QB{MAX_CANVAS_ID_SIZE}s"
 )  # seq_num + cmd_type + canvas_id
 
 # Placeholder for Stage 6
 ADD_WIDGET_STRUCT = struct.Struct(
-    f"=QB{MAX_CANVAS_ID_SIZE}s{MAX_WIDGET_ID_SIZE}s{MAX_WIDGET_TYPE_SIZE}s"
+    f"<QB{MAX_CANVAS_ID_SIZE}s{MAX_WIDGET_ID_SIZE}s{MAX_WIDGET_TYPE_SIZE}s"
 )  # seq_num + cmd_type + canvas_id + widget_id + widget_type
 
-ACK_STRUCT = struct.Struct("=Q")  # seq_num only
+ACK_STRUCT = struct.Struct("<Q")  # seq_num only
 
 
 @dataclass

--- a/tests/test_ipc_structs.py
+++ b/tests/test_ipc_structs.py
@@ -1,0 +1,121 @@
+"""Tests for IPC command struct serialization.
+
+Covers: UPDATE_TITLE / UPDATE_SIZE separation, cross-platform alignment,
+and CommandType enum values (closes #144, #151).
+"""
+
+import pytest
+
+from champi_imgui.ipc.command_types import CommandType
+from champi_imgui.ipc.structs import (
+    UPDATE_SIZE_STRUCT,
+    UPDATE_TITLE_STRUCT,
+    get_struct_size,
+    pack_command,
+    unpack_command,
+)
+
+
+class TestCommandTypeValues:
+    def test_update_title_value(self) -> None:
+        assert CommandType.UPDATE_TITLE == 3
+
+    def test_update_size_value(self) -> None:
+        assert CommandType.UPDATE_SIZE == 4
+
+    def test_shutdown_value(self) -> None:
+        assert CommandType.SHUTDOWN == 5
+
+    def test_no_update_state(self) -> None:
+        names = [m.name for m in CommandType]
+        assert "UPDATE_STATE" not in names
+
+
+class TestUpdateTitleRoundTrip:
+    def test_pack_unpack_preserves_title(self) -> None:
+        packed = pack_command(CommandType.UPDATE_TITLE, 1, canvas_id="main", title="Hello")
+        result = unpack_command(packed)
+        assert result.command_type == CommandType.UPDATE_TITLE
+        assert result.data["canvas_id"] == "main"
+        assert result.data["title"] == "Hello"
+
+    def test_title_result_has_no_size_fields(self) -> None:
+        packed = pack_command(CommandType.UPDATE_TITLE, 1, canvas_id="x", title="T")
+        result = unpack_command(packed)
+        assert "width" not in result.data
+        assert "height" not in result.data
+
+    def test_get_struct_size_update_title(self) -> None:
+        assert get_struct_size(CommandType.UPDATE_TITLE) == UPDATE_TITLE_STRUCT.size
+
+    def test_unicode_title_round_trips(self) -> None:
+        packed = pack_command(CommandType.UPDATE_TITLE, 99, canvas_id="c", title="Ñoño")
+        result = unpack_command(packed)
+        assert result.data["title"] == "Ñoño"
+
+
+class TestUpdateSizeRoundTrip:
+    def test_pack_unpack_preserves_dimensions(self) -> None:
+        packed = pack_command(
+            CommandType.UPDATE_SIZE, 2, canvas_id="main", width=1920, height=1080
+        )
+        result = unpack_command(packed)
+        assert result.command_type == CommandType.UPDATE_SIZE
+        assert result.data["width"] == 1920
+        assert result.data["height"] == 1080
+
+    def test_size_result_has_no_title_field(self) -> None:
+        packed = pack_command(CommandType.UPDATE_SIZE, 2, canvas_id="x", width=800, height=600)
+        result = unpack_command(packed)
+        assert "title" not in result.data
+
+    def test_get_struct_size_update_size(self) -> None:
+        assert get_struct_size(CommandType.UPDATE_SIZE) == UPDATE_SIZE_STRUCT.size
+
+    @pytest.mark.parametrize("width,height", [
+        (800, 600),
+        (1920, 1080),
+        (3840, 2160),
+        (1, 1),
+        (65535, 65535),
+    ])
+    def test_various_dimensions_round_trip(self, width: int, height: int) -> None:
+        packed = pack_command(CommandType.UPDATE_SIZE, 1, canvas_id="c", width=width, height=height)
+        result = unpack_command(packed)
+        assert result.data["width"] == width
+        assert result.data["height"] == height
+
+
+class TestCrossContamination:
+    def test_update_title_does_not_affect_size(self) -> None:
+        """A title-only pack must not contain width/height fields."""
+        packed = pack_command(CommandType.UPDATE_TITLE, 5, canvas_id="cv", title="New Title")
+        result = unpack_command(packed)
+        assert result.data.get("title") == "New Title"
+        assert "width" not in result.data
+        assert "height" not in result.data
+
+    def test_update_size_does_not_affect_title(self) -> None:
+        """A size-only pack must not contain a title field."""
+        packed = pack_command(CommandType.UPDATE_SIZE, 6, canvas_id="cv", width=640, height=480)
+        result = unpack_command(packed)
+        assert result.data.get("width") == 640
+        assert result.data.get("height") == 480
+        assert "title" not in result.data
+
+
+class TestStructAlignment:
+    def test_update_size_width_field_is_4byte_aligned(self) -> None:
+        """Width integer must start at a 4-byte aligned offset (ARM64 requirement)."""
+        import struct as _struct
+        # offset after QB + 64s + 3x padding
+        offset = _struct.calcsize("<QB64s3x")
+        assert offset % 4 == 0, f"width field at offset {offset} is not 4-byte aligned"
+
+    def test_update_size_round_trip_exact_values(self) -> None:
+        """Guard against byte-swap or misread on big-endian / strict-alignment platforms."""
+        for w, h in [(0x1234, 0x5678), (0xDEAD, 0xBEEF), (1920, 1080)]:
+            packed = pack_command(CommandType.UPDATE_SIZE, 1, canvas_id="a", width=w, height=h)
+            result = unpack_command(packed)
+            assert result.data["width"] == w, f"width mismatch: expected {w:#x}, got {result.data['width']:#x}"
+            assert result.data["height"] == h, f"height mismatch: expected {h:#x}, got {result.data['height']:#x}"


### PR DESCRIPTION
## Summary

- Changes all struct format strings from `=` (native byte order) to `<` (explicit little-endian) for consistent cross-platform wire format
- Adds 3 padding bytes before the `II` fields in `UPDATE_SIZE_STRUCT` so `width` and `height` land at offset 76 (4-byte aligned), preventing incorrect reads on Apple Silicon ARM64 strict-alignment mode
- Fixes `pyproject.toml` to use `[tool.uv.sources]` for local path deps instead of inline `@ path` syntax
- Adds `tests/test_ipc_structs.py` with 20 tests covering round-trips, cross-contamination guards, and the alignment invariant

Closes #144
Closes #151

## Test plan

- [ ] `uv run python -m pytest tests/ -q` — 886 tests pass, 69.33% coverage
- [ ] `uv tool run ruff check src/` — clean
- [ ] `uv run python -m mypy src/` — clean
- [ ] Round-trip test: pack then unpack `UPDATE_SIZE(width=0xDEAD, height=0xBEEF)` yields exact values
- [ ] Alignment test: `width` field starts at offset 76 (divisible by 4)