### PR TITLE
feat(canvas): add render thread error surfacing and health MCP tools

### DIFF
--- a/src/champi_imgui/cli.py
+++ b/src/champi_imgui/cli.py
@@ -1,6 +1,18 @@
-"""CLI entry point for champi-imgui MCP server."""
+"""CLI entry point for champi-imgui MCP server.
+
+Required environment variables for canvas rendering:
+  DISPLAY        - X11 display socket (e.g. :0 or :1)
+  XAUTHORITY     - X11 auth cookie file (e.g. /home/user/.Xauthority)
+  WAYLAND_DISPLAY - Wayland socket (alternative to DISPLAY on Wayland sessions)
+
+When running as a systemd service, add to the [Service] section:
+  Environment="DISPLAY=:0"
+  Environment="XAUTHORITY=/home/YOUR_USER/.Xauthority"
+Or use: PassEnvironment=DISPLAY XAUTHORITY WAYLAND_DISPLAY
+"""
 
 import atexit
+import os
 import signal
 import sys
 
@@ -34,6 +46,13 @@ def main() -> None:
     )
 
     logger.info("Starting champi-imgui MCP server...")
+
+    if not os.environ.get("DISPLAY") and not os.environ.get("WAYLAND_DISPLAY"):
+        logger.warning(
+            "Neither DISPLAY nor WAYLAND_DISPLAY is set — canvas windows will likely "
+            "fail to render. Set DISPLAY=:0 or ensure the display server environment "
+            "is propagated to this process."
+        )
 
     # Register cleanup handlers
     atexit.register(cleanup)

--- a/src/champi_imgui/core/canvas.py
+++ b/src/champi_imgui/core/canvas.py
@@ -66,6 +66,7 @@ class Canvas:
         # Thread control
         self._running = False
         self._render_thread: threading.Thread | None = None
+        self._render_error: Exception | None = None
 
         # X11 window ID, populated after the render thread initialises the window
         self._window_id: int | None = None
@@ -110,6 +111,15 @@ class Canvas:
         )
         self._render_thread.start()
         logger.info(f"Canvas '{self.state.canvas_id}' started in background thread")
+
+    def is_render_healthy(self) -> bool:
+        """Return True when the render thread is alive and has not crashed."""
+        return (
+            self._running
+            and self._render_thread is not None
+            and self._render_thread.is_alive()
+            and self._render_error is None
+        )
 
     def stop(self) -> None:
         """Stop canvas rendering and cleanup."""
@@ -209,7 +219,8 @@ class Canvas:
         try:
             hello_imgui.run(runner_params)
         except Exception as e:
-            logger.error(f"Error in render loop for '{self.state.canvas_id}': {e}")
+            self._render_error = e
+            logger.error(f"Render loop crashed for '{self.state.canvas_id}': {e}")
         finally:
             self._running = False
 

--- a/src/champi_imgui/server/main.py
+++ b/src/champi_imgui/server/main.py
@@ -4,6 +4,8 @@ Provides MCP tools for creating and managing Canvas windows and widgets
 through shared memory IPC.
 """
 
+import os
+import time
 from typing import Any
 
 from fastmcp import FastMCP
@@ -108,6 +110,19 @@ from champi_imgui.widgets.slider import (
     DragIntWidget,
     SliderFloatWidget,
     SliderIntWidget,
+)
+
+# Log display and graphics env vars at import time for render diagnostics
+_SERVER_START_TIME = time.monotonic()
+logger.info(
+    "Display environment: DISPLAY={} WAYLAND_DISPLAY={} XDG_SESSION_TYPE={} "
+    "LIBGL_ALWAYS_SOFTWARE={} XAUTHORITY={}".format(
+        os.environ.get("DISPLAY"),
+        os.environ.get("WAYLAND_DISPLAY"),
+        os.environ.get("XDG_SESSION_TYPE"),
+        os.environ.get("LIBGL_ALWAYS_SOFTWARE"),
+        os.environ.get("XAUTHORITY"),
+    )
 )
 
 # Global canvas manager (single instance for all MCP tool calls)
@@ -484,6 +499,66 @@ def shutdown_canvas(canvas_id: str) -> dict[str, Any]:
             "success": False,
             "error": str(e),
         }
+
+
+@mcp.tool()
+def get_render_error(canvas_id: str) -> dict[str, Any]:
+    """Return the last exception from the render thread for a canvas, or null if healthy.
+
+    Args:
+        canvas_id: Canvas identifier
+
+    Returns:
+        Dict with error string and type, or null values if no error has occurred
+    """
+    try:
+        canvas = canvas_manager.get_canvas(canvas_id)
+        if canvas is None:
+            return {"success": False, "error": f"Canvas '{canvas_id}' not found"}
+        err = canvas._render_error
+        return {
+            "success": True,
+            "data": {
+                "canvas_id": canvas_id,
+                "error": str(err) if err is not None else None,
+                "error_type": type(err).__name__ if err is not None else None,
+            },
+        }
+    except Exception as e:
+        logger.error(f"Error getting render error for '{canvas_id}': {e}")
+        return {"success": False, "error": str(e)}
+
+
+@mcp.tool()
+def get_render_health(canvas_id: str) -> dict[str, Any]:
+    """Return render thread health for a canvas: thread alive status and last error.
+
+    Args:
+        canvas_id: Canvas identifier
+
+    Returns:
+        Dict with thread_alive, is_healthy, and last_error fields
+    """
+    try:
+        canvas = canvas_manager.get_canvas(canvas_id)
+        if canvas is None:
+            return {"success": False, "error": f"Canvas '{canvas_id}' not found"}
+        thread_alive = (
+            canvas._render_thread is not None and canvas._render_thread.is_alive()
+        )
+        err = canvas._render_error
+        return {
+            "success": True,
+            "data": {
+                "canvas_id": canvas_id,
+                "thread_alive": thread_alive,
+                "is_healthy": canvas.is_render_healthy(),
+                "last_error": str(err) if err is not None else None,
+            },
+        }
+    except Exception as e:
+        logger.error(f"Error getting render health for '{canvas_id}': {e}")
+        return {"success": False, "error": str(e)}
 
 
 # ==============================================================================


### PR DESCRIPTION
## Summary

- `Canvas._render_error: Exception | None` — stores render-thread exceptions instead of silently dropping them
- `Canvas.is_render_healthy()` — returns True only when thread is alive and no crash has been recorded
- `get_render_error(canvas_id)` MCP tool — returns last crash exception and type
- `get_render_health(canvas_id)` MCP tool — returns `thread_alive`, `is_healthy`, `last_error`
- Logs `DISPLAY`, `WAYLAND_DISPLAY`, `XDG_SESSION_TYPE`, `LIBGL_ALWAYS_SOFTWARE`, `XAUTHORITY` at server import time
- CLI warns when neither `DISPLAY` nor `WAYLAND_DISPLAY` is set
- Documents systemd `PassEnvironment` / `Environment=` config in `cli.py` module docstring

Closes #127
Closes #130
Closes #132
Closes #134

## Test plan

- [ ] `uv run python -m pytest tests/ -q` — 866 tests pass, 68.63% coverage
- [ ] `uv tool run ruff check src/` — clean
- [ ] `uv run python -m mypy src/` — clean
- [ ] `get_render_health("nonexistent")` returns `{"success": False, "error": "..."}`
- [ ] `get_render_error("nonexistent")` returns `{"success": False, "error": "..."}`