### PR TITLE
feat(observability): MCP System State Reporter

### DIFF
--- a/src/champi_imgui/core/binding.py
+++ b/src/champi_imgui/core/binding.py
@@ -105,6 +105,17 @@ class DataStore:
         except (KeyError, TypeError):
             return default
 
+    def to_diagnostics(self) -> dict[str, Any]:
+        """Return a snapshot of data store state for diagnostics."""
+        return {
+            "key_count": len(self._data),
+            "signal_path_count": len(self._signals),
+            "signal_paths": [
+                {"path": path, "receiver_count": len(sig.receivers)}
+                for path, sig in self._signals.items()
+            ],
+        }
+
 
 class BindingManager:
     """Manager for widget data bindings."""
@@ -167,6 +178,13 @@ class BindingManager:
     def clear(self) -> None:
         """Clear all bindings."""
         self.bindings.clear()
+
+    def to_diagnostics(self) -> dict[str, Any]:
+        """Return a snapshot of binding state for diagnostics."""
+        return {
+            "binding_count": sum(len(v) for v in self.bindings.values()),
+            "paths": list(self.bindings.keys()),
+        }
 
     def _on_data_change(self, sender: object, **kwargs: Any) -> None:
         path = kwargs.get("path")

--- a/src/champi_imgui/core/events.py
+++ b/src/champi_imgui/core/events.py
@@ -125,3 +125,11 @@ class EventQueue:
         """
         with self._lock:
             return {k: list(v) for k, v in self._subscriptions.items()}
+
+    def to_diagnostics(self) -> dict[str, Any]:
+        """Return a snapshot of event queue state for diagnostics."""
+        with self._lock:
+            return {
+                "pending_count": len(self._queue),
+                "subscription_count": len(self._subscriptions),
+            }

--- a/src/champi_imgui/core/serialization.py
+++ b/src/champi_imgui/core/serialization.py
@@ -181,3 +181,10 @@ class TemplateManager:
         except Exception as e:
             logger.error(f"Error deleting template: {e}")
             return False
+
+    def to_diagnostics(self) -> dict[str, Any]:
+        """Return a snapshot of template state for diagnostics."""
+        saved: list[str] = []
+        if self.templates_dir.exists():
+            saved = [p.stem for p in self.templates_dir.glob("*.json")]
+        return {"saved": saved, "cached": list(self._cache.keys())}

--- a/src/champi_imgui/extensions/animation.py
+++ b/src/champi_imgui/extensions/animation.py
@@ -4,6 +4,7 @@ import math
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 from imgui_bundle import imgui
 from loguru import logger
@@ -237,3 +238,22 @@ class AnimationManager:
     def clear(self) -> None:
         """Remove all animations."""
         self.animations.clear()
+
+    def to_diagnostics(self) -> dict[str, Any]:
+        """Return a snapshot of animation state for diagnostics."""
+        snapshot = list(self.animations.values())
+        return {
+            "active_count": sum(1 for a in snapshot if a.state == AnimationState.RUNNING),
+            "total_count": len(snapshot),
+            "animations": [
+                {
+                    "name": a.name,
+                    "state": a.state.value,
+                    "easing": a.easing.value,
+                    "current_value": a.current_value,
+                    "duration": a.duration,
+                    "loop": a.loop,
+                }
+                for a in snapshot
+            ],
+        }

--- a/src/champi_imgui/extensions/notification.py
+++ b/src/champi_imgui/extensions/notification.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 from imgui_bundle import imgui
 from loguru import logger
@@ -131,6 +132,18 @@ class NotificationManager:
                     notification.visible = False
         imgui.end()
         imgui.pop_style_color(2)
+
+    def to_diagnostics(self) -> dict[str, Any]:
+        """Return a snapshot of notification state for diagnostics."""
+        recent = self.notifications[-5:] if self.notifications else []
+        return {
+            "queued_count": len(self.notifications),
+            "max_notifications": self.max_notifications,
+            "recent": [
+                {"title": n.title, "message": n.message, "type": n.type.value}
+                for n in recent
+            ],
+        }
 
     def _get_notification_colors(
         self, type: NotificationType

--- a/src/champi_imgui/layout/manager.py
+++ b/src/champi_imgui/layout/manager.py
@@ -1,6 +1,7 @@
 """Layout manager for arranging widgets."""
 
 from enum import Enum
+from typing import Any
 
 from imgui_bundle import imgui
 from loguru import logger
@@ -129,6 +130,14 @@ class LayoutManager:
     def set_next_item_width(self, width: float) -> None:
         """Set width for next item only."""
         imgui.set_next_item_width(width)
+
+    def to_diagnostics(self) -> dict[str, Any]:
+        """Return a snapshot of layout state for diagnostics."""
+        return {
+            "mode": self.mode.value,
+            "spacing": self.spacing,
+            "grid_columns": self.grid_columns,
+        }
 
 
 class AutoLayout:

--- a/src/champi_imgui/server/main.py
+++ b/src/champi_imgui/server/main.py
@@ -11,11 +11,13 @@ from typing import Any
 from fastmcp import FastMCP
 from loguru import logger
 
+import champi_imgui
 from champi_imgui.core.binding import BindingManager, DataStore
 from champi_imgui.core.canvas import CanvasManager
 from champi_imgui.core.codegen import CodeGenerator, TemplateCodeGenerator
 from champi_imgui.core.events import EventQueue
 from champi_imgui.core.serialization import TemplateManager, UIExporter, UIImporter
+from champi_imgui.core.state import canvas_updated, widget_created, widget_updated
 from champi_imgui.core.widget import set_event_queue
 from champi_imgui.extensions.animation import AnimationManager, EasingFunction
 from champi_imgui.extensions.file_dialog import (
@@ -558,6 +560,117 @@ def get_render_health(canvas_id: str) -> dict[str, Any]:
         }
     except Exception as e:
         logger.error(f"Error getting render health for '{canvas_id}': {e}")
+        return {"success": False, "error": str(e)}
+
+
+@mcp.tool()
+def get_system_state() -> dict[str, Any]:
+    """Return a full snapshot of the champi-imgui server's internal state.
+
+    Includes version, uptime, canvas list, all manager diagnostics, and
+    blinker signal receiver counts. Useful for observability and debugging.
+
+    Returns:
+        Dict with version, uptime_seconds, canvas_count, canvases list,
+        managers dict, and signals dict.
+    """
+    try:
+        canvas_ids = canvas_manager.list_canvases()
+        canvases = []
+        for cid in canvas_ids:
+            canvas = canvas_manager.get_canvas(cid)
+            if canvas is None:
+                continue
+            canvases.append(
+                {
+                    "canvas_id": cid,
+                    "title": canvas.state.title,
+                    "size": list(canvas.state.size),
+                    "widget_count": len(canvas.widget_registry.get_all()),
+                    "is_healthy": canvas.is_render_healthy(),
+                    "last_error": str(canvas._render_error)
+                    if canvas._render_error is not None
+                    else None,
+                }
+            )
+
+        return {
+            "success": True,
+            "data": {
+                "version": champi_imgui.__version__,
+                "uptime_seconds": round(time.monotonic() - _SERVER_START_TIME, 2),
+                "canvas_count": len(canvas_ids),
+                "canvases": canvases,
+                "managers": {
+                    "animations": animation_manager.to_diagnostics(),
+                    "data_store": data_store.to_diagnostics(),
+                    "bindings": binding_manager.to_diagnostics(),
+                    "layout": layout_manager.to_diagnostics(),
+                    "themes": theme_manager.to_diagnostics(),
+                    "templates": template_manager.to_diagnostics(),
+                    "notifications": notification_manager.to_diagnostics(),
+                    "events": event_queue.to_diagnostics(),
+                },
+                "signals": {
+                    "canvas_updated": len(canvas_updated.receivers),
+                    "widget_created": len(widget_created.receivers),
+                    "widget_updated": len(widget_updated.receivers),
+                },
+            },
+        }
+    except Exception as e:
+        logger.error(f"Error getting system state: {e}")
+        return {"success": False, "error": str(e)}
+
+
+@mcp.tool()
+def get_canvas_diagnostics(canvas_id: str) -> dict[str, Any]:
+    """Return detailed diagnostics for a specific canvas.
+
+    Includes canvas state, widget list, and render thread health.
+
+    Args:
+        canvas_id: Canvas identifier
+
+    Returns:
+        Dict with canvas state snapshot and render health details.
+    """
+    try:
+        canvas = canvas_manager.get_canvas(canvas_id)
+        if canvas is None:
+            return {"success": False, "error": f"Canvas '{canvas_id}' not found"}
+
+        widgets = []
+        for wid, widget in canvas.widget_registry.get_all().items():
+            widgets.append(
+                {
+                    "widget_id": wid,
+                    "widget_type": widget.__class__.__name__,
+                    "visible": widget.state.visible,
+                    "enabled": widget.state.enabled,
+                }
+            )
+
+        return {
+            "success": True,
+            "data": {
+                "canvas_id": canvas_id,
+                "title": canvas.state.title,
+                "size": list(canvas.state.size),
+                "widget_count": len(widgets),
+                "widgets": widgets,
+                "render": {
+                    "is_healthy": canvas.is_render_healthy(),
+                    "thread_alive": canvas._render_thread is not None
+                    and canvas._render_thread.is_alive(),
+                    "last_error": str(canvas._render_error)
+                    if canvas._render_error is not None
+                    else None,
+                },
+            },
+        }
+    except Exception as e:
+        logger.error(f"Error getting canvas diagnostics for '{canvas_id}': {e}")
         return {"success": False, "error": str(e)}
 
 

--- a/src/champi_imgui/themes/manager.py
+++ b/src/champi_imgui/themes/manager.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Any
 
 from imgui_bundle import imgui
 from loguru import logger
@@ -173,6 +174,13 @@ class ThemeManager:
     def list_themes(self) -> list[str]:
         """List all registered theme names."""
         return list(self.themes.keys())
+
+    def to_diagnostics(self) -> dict[str, Any]:
+        """Return a snapshot of theme manager state for diagnostics."""
+        return {
+            "current": self.current_theme.name if self.current_theme else None,
+            "available": list(self.themes.keys()),
+        }
 
     def _apply_colors(self, colors: ThemeColors) -> None:
         style = imgui.get_style()

--- a/tests/test_system_state.py
+++ b/tests/test_system_state.py
@@ -1,0 +1,288 @@
+"""Tests for to_diagnostics() methods and system-state MCP tools (issues #135–#140)."""
+
+from unittest.mock import MagicMock, patch
+
+
+# ─────────────────────────── AnimationManager ────────────────────────────────
+
+def test_animation_manager_diagnostics_empty():
+    from champi_imgui.extensions.animation import AnimationManager
+
+    mgr = AnimationManager()
+    d = mgr.to_diagnostics()
+    assert d["active_count"] == 0
+    assert d["total_count"] == 0
+    assert d["animations"] == []
+
+
+def test_animation_manager_diagnostics_enum_values():
+    from champi_imgui.extensions.animation import AnimationManager, AnimationState, EasingFunction
+
+    mgr = AnimationManager()
+    mgr.create("fade", 0.0, 1.0, 0.5, easing=EasingFunction.LINEAR)
+    d = mgr.to_diagnostics()
+    assert d["total_count"] == 1
+    anim = d["animations"][0]
+    # state and easing must be string values, not enum instances
+    assert isinstance(anim["state"], str)
+    assert isinstance(anim["easing"], str)
+    assert anim["state"] == AnimationState.IDLE.value
+    assert anim["easing"] == EasingFunction.LINEAR.value
+
+
+# ─────────────────────────── NotificationManager ─────────────────────────────
+
+def test_notification_manager_diagnostics_empty():
+    from champi_imgui.extensions.notification import NotificationManager
+
+    mgr = NotificationManager()
+    d = mgr.to_diagnostics()
+    assert d["queued_count"] == 0
+    assert d["recent"] == []
+
+
+def test_notification_manager_diagnostics_with_entry():
+    from champi_imgui.extensions.notification import NotificationManager, NotificationType
+
+    mgr = NotificationManager()
+    with patch("champi_imgui.extensions.notification.imgui") as mock_imgui:
+        mock_imgui.get_time.return_value = 0.0
+        mgr.add("Title", "Body", NotificationType.INFO, duration=5.0)
+    d = mgr.to_diagnostics()
+    assert d["queued_count"] == 1
+    n = d["recent"][0]
+    assert isinstance(n["type"], str)
+    assert n["type"] == NotificationType.INFO.value
+
+
+# ──────────────────────────── LayoutManager ──────────────────────────────────
+
+def test_layout_manager_diagnostics_defaults():
+    from champi_imgui.layout.manager import LayoutManager, LayoutMode
+
+    mgr = LayoutManager()
+    d = mgr.to_diagnostics()
+    assert d["mode"] == LayoutMode.FREE.value
+    assert isinstance(d["mode"], str)
+    assert "spacing" in d
+    assert "grid_columns" in d
+
+
+def test_layout_manager_diagnostics_after_mode_change():
+    from champi_imgui.layout.manager import LayoutManager, LayoutMode
+
+    mgr = LayoutManager()
+    mgr.set_mode(LayoutMode.GRID)
+    mgr.set_grid_columns(4)
+    d = mgr.to_diagnostics()
+    assert d["mode"] == LayoutMode.GRID.value
+    assert d["grid_columns"] == 4
+
+
+# ──────────────────────────── DataStore ──────────────────────────────────────
+
+def test_data_store_diagnostics_empty():
+    from champi_imgui.core.binding import DataStore
+
+    ds = DataStore()
+    d = ds.to_diagnostics()
+    assert d["key_count"] == 0
+    assert d["signal_path_count"] == 0
+    assert d["signal_paths"] == []
+
+
+def test_data_store_diagnostics_with_data():
+    from champi_imgui.core.binding import DataStore
+
+    ds = DataStore()
+    ds.set("foo", 42)
+    ds.set("bar.baz", "hello")
+    d = ds.to_diagnostics()
+    assert d["key_count"] == 2
+    assert d["signal_path_count"] == 2
+    paths = [p["path"] for p in d["signal_paths"]]
+    assert "foo" in paths
+    assert "bar.baz" in paths
+
+
+# ─────────────────────────── BindingManager ──────────────────────────────────
+
+def test_binding_manager_diagnostics_empty():
+    from champi_imgui.core.binding import BindingManager, DataStore
+
+    mgr = BindingManager(DataStore())
+    d = mgr.to_diagnostics()
+    assert d["binding_count"] == 0
+    assert d["paths"] == []
+
+
+def test_binding_manager_diagnostics_with_binding():
+    from champi_imgui.core.binding import BindingManager, DataStore
+
+    ds = DataStore()
+    mgr = BindingManager(ds)
+    mgr.bind("sensor.temp", "label_01", "text")
+    d = mgr.to_diagnostics()
+    assert d["binding_count"] == 1
+    assert "sensor.temp" in d["paths"]
+
+
+# ──────────────────────────── EventQueue ─────────────────────────────────────
+
+def test_event_queue_diagnostics_empty():
+    from champi_imgui.core.events import EventQueue
+
+    q = EventQueue()
+    d = q.to_diagnostics()
+    assert d["pending_count"] == 0
+    assert d["subscription_count"] == 0
+
+
+def test_event_queue_diagnostics_with_subscription():
+    from champi_imgui.core.events import EventQueue
+
+    q = EventQueue()
+    q.subscribe("btn1", ["click"])
+    q.push("btn1", "click", {"x": 10})
+    d = q.to_diagnostics()
+    assert d["pending_count"] == 1
+    assert d["subscription_count"] == 1
+
+
+# ─────────────────────────── TemplateManager ─────────────────────────────────
+
+def test_template_manager_diagnostics_empty(tmp_path):
+    from champi_imgui.core.serialization import TemplateManager
+
+    mgr = TemplateManager(template_dir=str(tmp_path))
+    d = mgr.to_diagnostics()
+    assert d["saved"] == []
+    assert d["cached"] == []
+
+
+# ─────────────────────────── ThemeManager ────────────────────────────────────
+
+def test_theme_manager_diagnostics_no_theme():
+    from champi_imgui.themes.manager import Theme, ThemeManager
+
+    mgr = ThemeManager()
+    d = mgr.to_diagnostics()
+    assert d["current"] is None
+    assert d["available"] == []
+
+
+def test_theme_manager_diagnostics_after_register():
+    from champi_imgui.themes.manager import Theme, ThemeManager
+
+    mgr = ThemeManager()
+    mgr.register_theme(Theme(name="dark"))
+    mgr.register_theme(Theme(name="light"))
+    d = mgr.to_diagnostics()
+    assert d["current"] is None
+    assert set(d["available"]) == {"dark", "light"}
+
+
+# ──────────────────────── get_system_state tool ──────────────────────────────
+
+def _patch_managers(monkeypatch):
+    """Return a dict of minimal mock managers for server.main globals."""
+    from champi_imgui.server import main as m
+
+    mock_canvas_mgr = MagicMock()
+    mock_canvas_mgr.list_canvases.return_value = []
+
+    monkeypatch.setattr(m, "canvas_manager", mock_canvas_mgr)
+    monkeypatch.setattr(m, "animation_manager", MagicMock(**{"to_diagnostics.return_value": {"active_count": 0, "total_count": 0, "animations": []}}))
+    monkeypatch.setattr(m, "data_store", MagicMock(**{"to_diagnostics.return_value": {"key_count": 0, "signal_path_count": 0, "signal_paths": []}}))
+    monkeypatch.setattr(m, "binding_manager", MagicMock(**{"to_diagnostics.return_value": {"binding_count": 0, "paths": []}}))
+    monkeypatch.setattr(m, "layout_manager", MagicMock(**{"to_diagnostics.return_value": {"mode": "free", "spacing": 5.0, "grid_columns": 3}}))
+    monkeypatch.setattr(m, "theme_manager", MagicMock(**{"to_diagnostics.return_value": {"current": None, "available": []}}))
+    monkeypatch.setattr(m, "template_manager", MagicMock(**{"to_diagnostics.return_value": {"saved": [], "cached": []}}))
+    monkeypatch.setattr(m, "notification_manager", MagicMock(**{"to_diagnostics.return_value": {"pending_count": 0, "notifications": []}}))
+    monkeypatch.setattr(m, "event_queue", MagicMock(**{"to_diagnostics.return_value": {"pending_count": 0, "subscription_count": 0}}))
+
+    return mock_canvas_mgr
+
+
+def test_get_system_state_success(monkeypatch):
+    from champi_imgui.server import main as m
+
+    _patch_managers(monkeypatch)
+
+    result = m.get_system_state.fn()
+    assert result["success"] is True
+    data = result["data"]
+    assert "version" in data
+    assert "uptime_seconds" in data
+    assert data["uptime_seconds"] >= 0
+    assert data["canvas_count"] == 0
+    assert data["canvases"] == []
+    assert "managers" in data
+    assert "signals" in data
+    assert "canvas_updated" in data["signals"]
+    assert "widget_created" in data["signals"]
+    assert "widget_updated" in data["signals"]
+
+
+def test_get_system_state_managers_keys(monkeypatch):
+    from champi_imgui.server import main as m
+
+    _patch_managers(monkeypatch)
+
+    result = m.get_system_state.fn()
+    managers = result["data"]["managers"]
+    assert set(managers.keys()) == {
+        "animations", "data_store", "bindings", "layout",
+        "themes", "templates", "notifications", "events",
+    }
+
+
+# ────────────────────────── get_canvas_diagnostics ───────────────────────────
+
+def test_get_canvas_diagnostics_not_found(monkeypatch):
+    from champi_imgui.server import main as m
+
+    mock_mgr = MagicMock()
+    mock_mgr.get_canvas.return_value = None
+    monkeypatch.setattr(m, "canvas_manager", mock_mgr)
+
+    result = m.get_canvas_diagnostics.fn("missing_canvas")
+    assert result["success"] is False
+    assert "not found" in result["error"]
+
+
+def test_get_canvas_diagnostics_healthy_canvas(monkeypatch):
+    from champi_imgui.server import main as m
+
+    mock_widget = MagicMock()
+    mock_widget.__class__.__name__ = "ButtonWidget"
+    mock_widget.state.visible = True
+    mock_widget.state.enabled = True
+
+    mock_registry = MagicMock()
+    mock_registry.get_all.return_value = {"btn1": mock_widget}
+
+    mock_canvas = MagicMock()
+    mock_canvas.state.title = "Test Canvas"
+    mock_canvas.state.size = (800, 600)
+    mock_canvas.widget_registry = mock_registry
+    mock_canvas.is_render_healthy.return_value = True
+    mock_canvas._render_thread = MagicMock()
+    mock_canvas._render_thread.is_alive.return_value = True
+    mock_canvas._render_error = None
+
+    mock_mgr = MagicMock()
+    mock_mgr.get_canvas.return_value = mock_canvas
+    monkeypatch.setattr(m, "canvas_manager", mock_mgr)
+
+    result = m.get_canvas_diagnostics.fn("canvas1")
+    assert result["success"] is True
+    data = result["data"]
+    assert data["canvas_id"] == "canvas1"
+    assert data["title"] == "Test Canvas"
+    assert data["size"] == [800, 600]
+    assert data["widget_count"] == 1
+    assert len(data["widgets"]) == 1
+    assert data["widgets"][0]["widget_id"] == "btn1"
+    assert data["render"]["is_healthy"] is True
+    assert data["render"]["last_error"] is None

--- a/uv.lock
+++ b/uv.lock
@@ -159,7 +159,7 @@ wheels = [
 
 [[package]]
 name = "champi-imgui"
-version = "1.15.0"
+version = "1.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "blinker" },
@@ -197,6 +197,10 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+ecosystem = [
+    { name = "champi-ipc" },
+    { name = "champi-signals" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -211,6 +215,8 @@ dev = [
 requires-dist = [
     { name = "blinker", specifier = ">=1.9.0" },
     { name = "champi-imgui", extras = ["dev"], marker = "extra == 'all'" },
+    { name = "champi-ipc", marker = "extra == 'ecosystem'", directory = "../champi-ipc" },
+    { name = "champi-signals", marker = "extra == 'ecosystem'", directory = "../champi-signals" },
     { name = "commitizen", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "detect-secrets", marker = "extra == 'dev'", specifier = ">=1.4.0" },
     { name = "fastmcp", specifier = ">=2.12.0" },
@@ -230,7 +236,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "typing-extensions", specifier = ">=4.0.0" },
 ]
-provides-extras = ["dev", "all"]
+provides-extras = ["dev", "ecosystem", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -239,6 +245,63 @@ dev = [
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", specifier = ">=1.2.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+]
+
+[[package]]
+name = "champi-ipc"
+version = "0.1.0"
+source = { directory = "../champi-ipc" }
+dependencies = [
+    { name = "blinker" },
+    { name = "click" },
+    { name = "loguru" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "black", marker = "extra == 'dev'", specifier = ">=24.0.0" },
+    { name = "blinker", specifier = ">=1.7.0" },
+    { name = "click", specifier = ">=8.1.0" },
+    { name = "loguru", specifier = ">=0.7.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.6.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2.0" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "black", specifier = ">=26.3.1" }]
+
+[[package]]
+name = "champi-signals"
+version = "0.1.0"
+source = { directory = "../champi-signals" }
+dependencies = [
+    { name = "blinker" },
+    { name = "loguru" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "blinker", specifier = ">=1.7.0" },
+    { name = "commitizen", marker = "extra == 'dev'", specifier = ">=3.0.0" },
+    { name = "loguru", specifier = ">=0.7.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
+    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.1.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+]
+provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+docs = [
+    { name = "mkdocs-material", specifier = ">=9.5" },
+    { name = "mkdocstrings-python", specifier = ">=1.8" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `to_diagnostics()` to all manager classes (`AnimationManager`, `NotificationManager`, `LayoutManager`, `DataStore`, `BindingManager`, `EventQueue`, `TemplateManager`, `ThemeManager`) — each returning structured dicts using enum `.value` strings
- Add `get_system_state` MCP tool: returns version, uptime, per-canvas render health, all manager diagnostics, and blinker signal receiver counts
- Add `get_canvas_diagnostics(canvas_id)` MCP tool: returns canvas state snapshot (title, size, widget list) and render thread health
- 19 new unit tests covering all diagnostics methods and both MCP tools

## Issues closed

Closes #135, #136, #137, #138, #139, #140

## Test plan

- [ ] `uv run python -m pytest tests/test_system_state.py -v` — 19 tests pass
- [ ] `uv run python -m pytest tests/ -q` — full suite passes (905 tests, ≥67% coverage)
- [ ] `uv run --with ruff ruff check src/` — no lint errors