### PR TITLE
chore: apply ruff format fixes

### DIFF
--- a/src/champi_imgui/extensions/animation.py
+++ b/src/champi_imgui/extensions/animation.py
@@ -243,7 +243,9 @@ class AnimationManager:
         """Return a snapshot of animation state for diagnostics."""
         snapshot = list(self.animations.values())
         return {
-            "active_count": sum(1 for a in snapshot if a.state == AnimationState.RUNNING),
+            "active_count": sum(
+                1 for a in snapshot if a.state == AnimationState.RUNNING
+            ),
             "total_count": len(snapshot),
             "animations": [
                 {

--- a/src/champi_imgui/ipc/command_types.py
+++ b/src/champi_imgui/ipc/command_types.py
@@ -12,10 +12,10 @@ class CommandType(IntEnum):
 
     # Canvas management
     CREATE_CANVAS = 1  # Initialize new canvas (placeholder, canvas already exists)
-    CLEAR_CANVAS = 2   # Clear all widgets from canvas
-    UPDATE_TITLE = 3   # Update canvas title only
-    UPDATE_SIZE = 4    # Update canvas size (width + height together)
-    SHUTDOWN = 5       # Gracefully shutdown canvas
+    CLEAR_CANVAS = 2  # Clear all widgets from canvas
+    UPDATE_TITLE = 3  # Update canvas title only
+    UPDATE_SIZE = 4  # Update canvas size (width + height together)
+    SHUTDOWN = 5  # Gracefully shutdown canvas
 
     # Widget operations (placeholders for Stage 6)
     ADD_WIDGET = 10  # Add widget to canvas

--- a/src/champi_imgui/ipc/structs.py
+++ b/src/champi_imgui/ipc/structs.py
@@ -180,8 +180,8 @@ def unpack_command(data: bytes) -> CommandData:
         )
 
     elif command_type == CommandType.UPDATE_TITLE:
-        seq_num, cmd_type_int, canvas_id_bytes, title_bytes = UPDATE_TITLE_STRUCT.unpack(
-            data
+        seq_num, cmd_type_int, canvas_id_bytes, title_bytes = (
+            UPDATE_TITLE_STRUCT.unpack(data)
         )
         return CommandData(
             command_type=command_type,
@@ -193,8 +193,8 @@ def unpack_command(data: bytes) -> CommandData:
         )
 
     elif command_type == CommandType.UPDATE_SIZE:
-        seq_num, cmd_type_int, canvas_id_bytes, width, height = UPDATE_SIZE_STRUCT.unpack(
-            data
+        seq_num, cmd_type_int, canvas_id_bytes, width, height = (
+            UPDATE_SIZE_STRUCT.unpack(data)
         )
         return CommandData(
             command_type=command_type,


### PR DESCRIPTION
## Summary

- Apply `ruff format` to three files that were not properly formatted:
  `animation.py`, `command_types.py`, `structs.py`
- No logic changes, formatting only

## Test plan

- [ ] `uv run --with ruff ruff format --check src/` — clean
- [ ] `uv run --with ruff ruff check src/` — clean
- [ ] `uv run python -m pytest tests/ -q` — 905 tests pass