### PR TITLE
feat(canvas): poll render health in create_canvas + integration tests

### DIFF
--- a/src/champi_imgui/server/main.py
+++ b/src/champi_imgui/server/main.py
@@ -227,6 +227,21 @@ def create_canvas(
             auto_start=auto_start,
         )
 
+        if auto_start:
+            # Poll until the render thread is healthy or 2s elapses
+            deadline = time.monotonic() + 2.0
+            while time.monotonic() < deadline:
+                if canvas.is_render_healthy():
+                    break
+                time.sleep(0.05)
+            else:
+                err = canvas._render_error
+                return {
+                    "success": False,
+                    "error": "Render thread did not start within 2s"
+                    + (f": {err}" if err else ""),
+                }
+
         logger.info(f"Created canvas '{canvas_id}' via MCP tool")
 
         return {

--- a/tests/test_create_canvas_health_poll.py
+++ b/tests/test_create_canvas_health_poll.py
@@ -1,0 +1,100 @@
+"""Unit tests for create_canvas health-polling (issue #129).
+
+Tests the 2s render-thread wait added to the create_canvas MCP tool.
+All tests use mocks — no display required.
+"""
+
+import contextlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import champi_imgui.server.main as server
+from champi_imgui.core.canvas import CanvasManager
+
+
+@pytest.fixture(autouse=True)
+def fresh_canvas_manager(monkeypatch):
+    manager = CanvasManager()
+    original = server.canvas_manager
+    server.canvas_manager = manager
+    yield manager
+    for canvas in list(manager.canvases.values()):
+        with contextlib.suppress(Exception):
+            canvas.shm_manager.cleanup()
+    server.canvas_manager = original
+
+
+def test_create_canvas_already_exists(fresh_canvas_manager):
+    """Returns error when canvas_id already registered."""
+    mock_canvas = MagicMock()
+    fresh_canvas_manager.canvases["dup"] = mock_canvas
+
+    result = server.create_canvas.fn("dup")
+    assert result["success"] is False
+    assert "already exists" in result["error"]
+
+
+def test_create_canvas_auto_start_false_skips_poll(monkeypatch):
+    """auto_start=False returns success without any health polling."""
+    mock_canvas = MagicMock()
+    mock_canvas.state.to_dict.return_value = {"canvas_id": "c1"}
+
+    mock_mgr = MagicMock()
+    mock_mgr.get_canvas.return_value = None
+    mock_mgr.create_canvas.return_value = mock_canvas
+    monkeypatch.setattr(server, "canvas_manager", mock_mgr)
+
+    result = server.create_canvas.fn("c1", auto_start=False)
+    assert result["success"] is True
+    mock_canvas.is_render_healthy.assert_not_called()
+
+
+def test_create_canvas_healthy_on_first_poll(monkeypatch):
+    """Returns success when render thread is healthy immediately."""
+    mock_canvas = MagicMock()
+    mock_canvas.state.to_dict.return_value = {"canvas_id": "c2"}
+    mock_canvas.is_render_healthy.return_value = True
+
+    mock_mgr = MagicMock()
+    mock_mgr.get_canvas.return_value = None
+    mock_mgr.create_canvas.return_value = mock_canvas
+    monkeypatch.setattr(server, "canvas_manager", mock_mgr)
+
+    result = server.create_canvas.fn("c2", auto_start=True)
+    assert result["success"] is True
+    assert result["data"]["canvas_id"] == "c2"
+
+
+def test_create_canvas_timeout_returns_error(monkeypatch):
+    """Returns error when render thread never becomes healthy within 2s."""
+    mock_canvas = MagicMock()
+    mock_canvas.is_render_healthy.return_value = False
+    mock_canvas._render_error = RuntimeError("GL init failed")
+
+    mock_mgr = MagicMock()
+    mock_mgr.get_canvas.return_value = None
+    mock_mgr.create_canvas.return_value = mock_canvas
+    monkeypatch.setattr(server, "canvas_manager", mock_mgr)
+
+    # Speed up the test: make monotonic advance past deadline immediately
+    import time as _time
+
+    call_count = {"n": 0}
+    original_monotonic = _time.monotonic
+    start = original_monotonic()
+
+    def fast_monotonic():
+        call_count["n"] += 1
+        # First call returns start (sets deadline), subsequent calls skip past it
+        if call_count["n"] <= 1:
+            return start
+        return start + 3.0
+
+    monkeypatch.setattr(server.time, "monotonic", fast_monotonic)
+    monkeypatch.setattr(server.time, "sleep", lambda _: None)
+
+    result = server.create_canvas.fn("c3", auto_start=True)
+    assert result["success"] is False
+    assert "Render thread did not start" in result["error"]
+    assert "GL init failed" in result["error"]

--- a/tests/test_integration_canvas.py
+++ b/tests/test_integration_canvas.py
@@ -1,0 +1,68 @@
+"""Integration test: create_canvas + screenshot_canvas within 5s.
+
+Skipped automatically when no display is available (headless CI without Xvfb).
+Both tests share a single canvas to avoid hello_imgui re-init limitations.
+"""
+
+import os
+import time
+import uuid
+
+import pytest
+
+
+def _has_display() -> bool:
+    return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+
+
+pytestmark = pytest.mark.skipif(
+    not _has_display(),
+    reason="No display available — skipping live render integration test",
+)
+
+_CANVAS_ID = f"integ_{uuid.uuid4().hex[:8]}"
+
+
+@pytest.fixture(scope="module")
+def live_canvas():
+    """Create one canvas for the whole module, shut it down at the end."""
+    import champi_imgui.server.main as server
+
+    result = server.create_canvas.fn(
+        canvas_id=_CANVAS_ID, title="Integration Test", width=640, height=480
+    )
+    assert result["success"] is True, f"create_canvas failed: {result.get('error')}"
+    canvas = server.canvas_manager.get_canvas(_CANVAS_ID)
+    yield canvas
+    server.shutdown_canvas.fn(_CANVAS_ID)
+
+
+def test_create_canvas_render_thread_healthy(live_canvas):
+    """Render thread must be healthy after create_canvas returns."""
+    assert live_canvas.is_render_healthy(), "Render thread is not healthy"
+
+
+def test_create_canvas_screenshot_within_5s(live_canvas, tmp_path):
+    """End-to-end: take screenshot of running canvas, assert valid PNG within 5s."""
+    import champi_imgui.server.main as server
+
+    out_path = str(tmp_path / "screenshot.png")
+    deadline = time.monotonic() + 5.0
+    screenshot_result = None
+
+    while time.monotonic() < deadline:
+        screenshot_result = server.screenshot_canvas.fn(
+            canvas_id=_CANVAS_ID, filepath=out_path
+        )
+        if screenshot_result.get("success"):
+            break
+        time.sleep(0.25)
+
+    assert screenshot_result is not None
+    assert screenshot_result["success"] is True, (
+        f"screenshot_canvas failed: {screenshot_result.get('error')}"
+    )
+
+    with open(out_path, "rb") as f:
+        header = f.read(8)
+    assert header == b"\x89PNG\r\n\x1a\n", "Output file is not a valid PNG"


### PR DESCRIPTION
## Summary

- `create_canvas` with `auto_start=True` now polls `is_render_healthy()` for up to 2s before returning; returns `{"success": False, "error": ...}` if the render thread never starts
- Integration tests: canvas health check + PNG screenshot within 5s (auto-skipped without a display)
- Unit tests for all polling paths: guard, bypass, immediate success, 2s timeout

## Issues closed

Closes #128, #129, #131

## Test plan

- [ ] `uv run python -m pytest tests/test_create_canvas_health_poll.py -v` — 4 tests pass
- [ ] `uv run python -m pytest tests/test_integration_canvas.py -v` — 2 tests pass (with display) or skip (headless)
- [ ] `uv run python -m pytest tests/ -q` — 911 tests pass, ≥67% coverage
- [ ] `uv run --with ruff ruff check src/ && uv run --with ruff ruff format --check src/` — clean